### PR TITLE
Support ULWGL_ID env var

### DIFF
--- a/gamelauncher.py
+++ b/gamelauncher.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import tomllib
 from typing import Dict, Any, List, Set
 import gamelauncher_plugins
+from re import match
 
 # TODO: Only set the environment variables that are not empty
 import subprocess
@@ -239,7 +240,12 @@ def main() -> None:  # noqa: D103
     if getattr(args, "verb", None) and getattr(args, "verb", None) in verbs:
         verb = getattr(args, "verb", None)
 
-    env["STEAM_COMPAT_APP_ID"] = env["GAMEID"]
+    env["ULWGL_ID"] = env["GAMEID"]
+    env["STEAM_COMPAT_APP_ID"] = "0"
+
+    if match(r"^ulwgl-[\d\w]+$", env["ULWGL_ID"]):
+        env["STEAM_COMPAT_APP_ID"] = env["ULWGL_ID"][env["ULWGL_ID"].find("-") + 1 :]
+
     env["SteamAppId"] = env["STEAM_COMPAT_APP_ID"]
     env["SteamGameId"] = env["SteamAppId"]
     env["WINEPREFIX"] = Path(env["WINEPREFIX"]).expanduser().as_posix()

--- a/gamelauncher_test.py
+++ b/gamelauncher_test.py
@@ -1213,6 +1213,24 @@ class TestGameLauncher(unittest.TestCase):
                 "Expected the same value when setting --verb",
             )
 
+    def test_parse_args_store(self):
+        """Test parse_args --store."""
+        test_store = "gog"
+        with patch.object(
+            gamelauncher,
+            "parse_args",
+            return_value=argparse.Namespace(exe=self.test_exe, store=test_store),
+        ):
+            result = gamelauncher.parse_args()
+            self.assertIsInstance(
+                result, Namespace, "Expected a Namespace from parse_arg"
+            )
+            self.assertEqual(
+                result.store,
+                test_store,
+                "Expected the same value when setting --store",
+            )
+
     def test_parse_args_options(self):
         """Test parse_args --options."""
         with patch.object(

--- a/gamelauncher_test.py
+++ b/gamelauncher_test.py
@@ -37,6 +37,7 @@ class TestGameLauncher(unittest.TestCase):
             "SteamAppId": "",
             "SteamGameId": "",
             "STEAM_RUNTIME_LIBRARY_PATH": "",
+            "ULWGL_ID": "",
         }
         self.test_opts = "-foo -bar"
         # Proton verb
@@ -110,9 +111,14 @@ class TestGameLauncher(unittest.TestCase):
             # Check if the EXE is empty
             self.assertFalse(result_set_env["EXE"], "Expected EXE to be empty")
 
-        # Set remaining environment variables
-        self.env["STEAM_COMPAT_MOUNTS"] = self.env["STEAM_COMPAT_TOOL_PATHS"]
-        self.env["STEAM_COMPAT_APP_ID"] = self.env["GAMEID"]
+        self.env["ULWGL_ID"] = self.env["GAMEID"]
+        self.env["STEAM_COMPAT_APP_ID"] = "0"
+
+        if re.match(r"^ulwgl-[\d\w]+$", self.env["ULWGL_ID"]):
+            self.env["STEAM_COMPAT_APP_ID"] = self.env["ULWGL_ID"][
+                self.env["ULWGL_ID"].find("-") + 1 :
+            ]
+
         self.env["SteamAppId"] = self.env["STEAM_COMPAT_APP_ID"]
         self.env["SteamGameId"] = self.env["SteamAppId"]
         self.env["WINEPREFIX"] = Path(self.env["WINEPREFIX"]).expanduser().as_posix()
@@ -221,8 +227,14 @@ class TestGameLauncher(unittest.TestCase):
             self.assertEqual(result_set_env["PROTONPATH"], self.test_file)
             self.assertEqual(result_set_env["GAMEID"], self.test_file)
 
-        self.env["STEAM_COMPAT_MOUNTS"] = self.env["STEAM_COMPAT_TOOL_PATHS"]
-        self.env["STEAM_COMPAT_APP_ID"] = self.env["GAMEID"]
+        self.env["ULWGL_ID"] = self.env["GAMEID"]
+        self.env["STEAM_COMPAT_APP_ID"] = "0"
+
+        if re.match(r"^ulwgl-[\d\w]+$", self.env["ULWGL_ID"]):
+            self.env["STEAM_COMPAT_APP_ID"] = self.env["ULWGL_ID"][
+                self.env["ULWGL_ID"].find("-") + 1 :
+            ]
+
         self.env["SteamAppId"] = self.env["STEAM_COMPAT_APP_ID"]
         self.env["SteamGameId"] = self.env["SteamAppId"]
         self.env["WINEPREFIX"] = Path(self.env["WINEPREFIX"]).expanduser().as_posix()
@@ -298,8 +310,14 @@ class TestGameLauncher(unittest.TestCase):
             self.assertEqual(result_set_env["PROTONPATH"], self.test_file)
             self.assertEqual(result_set_env["GAMEID"], self.test_file)
 
-        self.env["STEAM_COMPAT_MOUNTS"] = self.env["STEAM_COMPAT_TOOL_PATHS"]
-        self.env["STEAM_COMPAT_APP_ID"] = self.env["GAMEID"]
+        self.env["ULWGL_ID"] = self.env["GAMEID"]
+        self.env["STEAM_COMPAT_APP_ID"] = "0"
+
+        if re.match(r"^ulwgl-[\d\w]+$", self.env["ULWGL_ID"]):
+            self.env["STEAM_COMPAT_APP_ID"] = self.env["ULWGL_ID"][
+                self.env["ULWGL_ID"].find("-") + 1 :
+            ]
+
         self.env["SteamAppId"] = self.env["STEAM_COMPAT_APP_ID"]
         self.env["SteamGameId"] = self.env["SteamAppId"]
         self.env["WINEPREFIX"] = Path(self.env["WINEPREFIX"]).expanduser().as_posix()
@@ -316,7 +334,6 @@ class TestGameLauncher(unittest.TestCase):
             self.env["PROTONPATH"] + ":" + Path(__file__).parent.as_posix()
         )
         self.env["STEAM_COMPAT_MOUNTS"] = self.env["STEAM_COMPAT_TOOL_PATHS"]
-
         # Create an empty Proton prefix when asked
         if not getattr(result, "exe", None) and not getattr(result, "config", None):
             self.env["EXE"] = ""
@@ -374,8 +391,14 @@ class TestGameLauncher(unittest.TestCase):
             self.assertEqual(result_set_env["PROTONPATH"], self.test_file)
             self.assertEqual(result_set_env["GAMEID"], self.test_file)
 
-        self.env["STEAM_COMPAT_MOUNTS"] = self.env["STEAM_COMPAT_TOOL_PATHS"]
-        self.env["STEAM_COMPAT_APP_ID"] = self.env["GAMEID"]
+        self.env["ULWGL_ID"] = self.env["GAMEID"]
+        self.env["STEAM_COMPAT_APP_ID"] = "0"
+
+        if re.match(r"^ulwgl-[\d\w]+$", self.env["ULWGL_ID"]):
+            self.env["STEAM_COMPAT_APP_ID"] = self.env["ULWGL_ID"][
+                self.env["ULWGL_ID"].find("-") + 1 :
+            ]
+
         self.env["SteamAppId"] = self.env["STEAM_COMPAT_APP_ID"]
         self.env["SteamGameId"] = self.env["SteamAppId"]
         self.env["WINEPREFIX"] = Path(self.env["WINEPREFIX"]).expanduser().as_posix()
@@ -469,9 +492,14 @@ class TestGameLauncher(unittest.TestCase):
                 "Expected the concat EXE and game options to not have trailing spaces",
             )
 
-        self.env["STEAM_COMPAT_MOUNTS"] = self.env["STEAM_COMPAT_TOOL_PATHS"]
-        self.env["STEAM_COMPAT_MOUNTS"] = self.env["STEAM_COMPAT_TOOL_PATHS"]
-        self.env["STEAM_COMPAT_APP_ID"] = self.env["GAMEID"]
+        self.env["ULWGL_ID"] = self.env["GAMEID"]
+        self.env["STEAM_COMPAT_APP_ID"] = "0"
+
+        if re.match(r"^ulwgl-[\d\w]+$", self.env["ULWGL_ID"]):
+            self.env["STEAM_COMPAT_APP_ID"] = self.env["ULWGL_ID"][
+                self.env["ULWGL_ID"].find("-") + 1 :
+            ]
+
         self.env["SteamAppId"] = self.env["STEAM_COMPAT_APP_ID"]
         self.env["SteamGameId"] = self.env["SteamAppId"]
         self.env["WINEPREFIX"] = Path(self.env["WINEPREFIX"]).expanduser().as_posix()


### PR DESCRIPTION
Adds `--store` option to CLI and sets the `ULWGL_ID` environment variable. 

Depends on https://github.com/Open-Wine-Components/ULWGL-launcher/pull/8