### PR TITLE
feat: support auto setting correct GAMEID for the application

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -288,7 +288,6 @@ def set_umu_id(umu_db: Path, env: dict[str, str]) -> dict[str, str]:
         while row := mm.readline():
             columns = row.split(b",")
             if store not in columns[1]:
-                row = b""
                 continue
             if columns[0] in parts:
                 env["GAMEID"] = columns[3].decode()


### PR DESCRIPTION
Based on some internal discussion, this pull request adds support for automatically setting the correct GAMEID for the application. This avoids the need of clients trying to figure out if there's a fix for the running game in their internal umu implementation or potentially getting it wrong. Instead, the client can simply delegate that work to umu-launcher. As a result, the umu-database will be fully and correctly leveraged, and clients can focus on improving their UX.

This feature can be enabled by passing 'none' to GAMEID and setting STORE to a valid store. For example:

```
GAMEID=none STORE=gog umu-run Games/umu/Flowers - Le Volume Sur Automne/FLOWERS.exe
```

Note: Currently this implementation matches by title name which is _typically_ found in the executable path.

TODO
- Basic tests
- Refactor for both executable name and title once the umu-database is updated for executable names
