### PR TITLE
umu_utils: use redirect_stdout context manager to redirect stdout to stderr for python-xlib

### DIFF
--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -3,7 +3,7 @@ import os
 import platform
 import sys
 from collections.abc import Generator
-from contextlib import contextmanager
+from contextlib import contextmanager, redirect_stdout
 from ctypes import CDLL, get_errno
 from ctypes.util import find_library
 from enum import IntFlag
@@ -248,7 +248,8 @@ def xdisplay(no: str):
     d: display.Display | None = None
 
     try:
-        d = display.Display(no)
+        with redirect_stdout(sys.stderr):
+            d = display.Display(no)
         yield d
     finally:
         if d is not None:


### PR DESCRIPTION
python-xlib has two `print()` statements in Xlib.xauth

* https://github.com/python-xlib/python-xlib/blob/master/Xlib/xauth.py#L92
* https://github.com/python-xlib/python-xlib/blob/master/Xlib/xauth.py#L95

which can cause issues when the output in stdout needs to be parsed later.

Note: this is certainly **NOT** thread-safe, and has global effect for as long as the context is active
https://docs.python.org/3/library/contextlib.html#contextlib.redirect_stdout