### PR TITLE
only run in steammode when running in a flatpak container

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -632,10 +632,11 @@ def run_command(command: tuple[Path | str, ...]) -> int:
         os.environ.get("XDG_CURRENT_DESKTOP") == "gamescope"
         or os.environ.get("XDG_SESSION_DESKTOP") == "gamescope"
     )
+    is_flatpak: bool = (os.environ.get("container") == "flatpak") # noqa: SIM112
     # Note: STEAM_MULTIPLE_XWAYLANDS is steam mode specific and is
     # documented to be a legacy env var.
     is_steammode: bool = (
-        is_gamescope_session and os.environ.get("STEAM_MULTIPLE_XWAYLANDS") == "1"
+        is_gamescope_session and os.environ.get("STEAM_MULTIPLE_XWAYLANDS") == "1" and is_flatpak
     )
 
     if not command:


### PR DESCRIPTION
the steammode code only needs to run when in a flatpak. Running that anyway can cause Problems if there are bugs in UMU (for example #470 also was an Issue when using Heroics AppImage, even though the Steam Reaper could have handled that properly on it's own)