### PR TITLE
Expand environemnt vars in config file

### DIFF
--- a/umu/umu_plugins.py
+++ b/umu/umu_plugins.py
@@ -63,9 +63,9 @@ def set_env_toml(
     env["UMU_CONFIG_FILE_DIR"] = str(config_path.parent)
 
     # Perform expansion of env vars for paths
-    env["WINEPREFIX"] = Template(env["WINEPREFIX"]).substitute(env)
-    env["PROTONPATH"] = Template(env["PROTONPATH"]).substitute(env)
-    env["EXE"] = Template(env["EXE"]).substitute(env)
+    env["WINEPREFIX"] = Template(env["WINEPREFIX"]).safe_substitute(env)
+    env["PROTONPATH"] = Template(env["PROTONPATH"]).safe_substitute(env)
+    env["EXE"] = Template(env["EXE"]).safe_substitute(env)
 
     _check_env(env)
 


### PR DESCRIPTION
I think having env var expansion in umu config files would be a very useful feature. I implemented a proof-of-concept which allows to express the paths in terms of each other. For example, `exe` can be specified relatively to `$WINEPREFIX`. I also implemented `UMU_CONFIG_FILE_DIR` which points to the directory containing the TOML config file. This is very handy if you want to keep the config file inside the wineprefix  and be able to move it easily without having to update all the paths.

```toml
[umu]
prefix = "${UMU_CONFIG_FILE_DIR}"
proton = "$WINEPREFIX/GE-Proton10-24"
exe = "$WINEPREFIX/drive_c/something.exe"
```

If you consider this something that could be added, I can work on updating the relevant docs and tests.
