### PR TITLE
feat: add steamrt4 app id

### DIFF
--- a/umu/__init__.py
+++ b/umu/__init__.py
@@ -2,6 +2,6 @@ __version__ = "1.2.9"  # noqa: D104
 __runtime_versions__ = (
     ("sniper", "steamrt3", "1628350"),
     ("soldier", "steamrt2", "1391110"),
-    ("steamrt4", "steamrt4", ""),
+    ("steamrt4", "steamrt4", "4183110"),
 )
 __runtime_version__ = __runtime_versions__[0]


### PR DESCRIPTION
The Steam App ID for Steam Linux Runtime 4.0 (steamrt4) is confirmed. With it, umu-launcher can download and assign steamrt4 for a compatibility tool that requires it. See https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/commit/fb57fb4a7c9bc3cca61b923a7fdf0a4e80efe618. See https://steamdb.info/app/891390/history/?changeid=32261617.
