### PR TITLE
Address some of the feedback in #293, update tests.

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,21 +39,20 @@ jobs:
       - name: Run shellcheck
         run: |
           shellcheck tests/*.sh
-      - name: Setup venv
-        run: |
-          uv venv --python 3.10
       - name: Test delta update
         run: |
           python3 tests/test_delta.py
           rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d" "$HOME/.cache/umu"
       - name: Test steamrt install
         run: |
+          uv venv --python 3.10 --clear
           source .venv/bin/activate
           sh tests/test_install.sh
           rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
       - name: Test steamrt install w/ tmpfs
         run: |
           sudo mount -o size=1G -t tmpfs none /tmp
+          uv venv --python 3.10 --clear
           source .venv/bin/activate
           sh tests/test_install.sh
           rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
@@ -64,44 +63,50 @@ jobs:
           source .venv/bin/activate
           PYTHON_GIL=0 sh tests/test_install.sh
           rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
-          uv venv --python 3.10 --clear
       - name: Test obsolete steamrt install
         run: |
+          uv venv --python 3.10 --clear
           source .venv/bin/activate
           sh tests/test_install_obsolete.sh
           rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
       - name: Test steamrt update
         run: |
+          uv venv --python 3.10 --clear
           source .venv/bin/activate
           sh tests/test_update.sh
           rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
       - name: Test steamrt resume
         run: |
+          uv venv --python 3.10 --clear
           source .venv/bin/activate
           sh tests/test_resume.sh
           rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d" "$HOME/.cache/umu"
       - name: Test Proton resume
         run: |
+          uv venv --python 3.10 --clear
           source .venv/bin/activate
           sh tests/test_proton_resume.sh
           rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d" "$HOME/.cache/umu"
       - name: Test Filelock
         run: |
+          uv venv --python 3.10 --clear
           source .venv/bin/activate
           sh tests/test_flock.sh
           rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d" "$HOME/.cache/umu"
       - name: Test winetricks
         run: |
+          uv venv --python 3.10 --clear
           source .venv/bin/activate
           sh tests/test_winetricks.sh
           rm -rf "$HOME/.local/share/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
       - name: Test configuration file
         run: |
-          uv venv --python 3.11
+          uv venv --python 3.11 --clear
           source .venv/bin/activate
           sh tests/test_config.sh
           rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d" "$HOME/.cache/umu"
       - name: Test offline launch
         run: |
+          uv venv --python 3.10 --clear
           source .venv/bin/activate
           sh tests/test_offline.sh

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "subprojects/python-xlib"]
 	path = subprojects/python-xlib
 	url = https://github.com/python-xlib/python-xlib.git
-[submodule "subprojects/vdf"]
-	path = subprojects/vdf
-	url = https://github.com/ValvePython/vdf.git

--- a/Makefile.in
+++ b/Makefile.in
@@ -23,7 +23,6 @@ FLATPAK ?= xfalse
 # Ex. Arch and Fedora have pyzstd but ubuntu and debian don't
 USE_SYSTEM_PYZSTD ?= xfalse
 USE_SYSTEM_URLLIB ?= xfalse
-USE_SYSTEM_VDF ?= xfalse
 
 INSTALLER_ARGS := -m installer $(OBJDIR)/umu_launcher*.whl
 ifdef DESTDIR
@@ -86,15 +85,11 @@ umu-install: umu-dist-install umu-delta-install umu-docs-install
 endif
 
 
-
 $(OBJDIR)/.build-umu-vendored: | $(OBJDIR)
 	$(info :: Building vendored dependencies )
 	@if [ "$(USE_SYSTEM_PYZSTD)" != "xtrue" ]; then \
 		sed -i 's/setuptools>=64,<74/setuptools/' subprojects/pyzstd/pyproject.toml; \
 		cd subprojects/pyzstd && $(PYTHON_INTERPRETER) -m build -wn -C=--build-option=--dynamic-link-zstd --outdir=$(OBJDIR); \
-	fi
-	@if [ "$(USE_SYSTEM_VDF)" != "xtrue" ]; then \
-		cd subprojects/vdf && $(PYTHON_INTERPRETER) -m build -wn --outdir=$(OBJDIR); \
 	fi
 	@if [ "$(USE_SYSTEM_URLLIB)" != "xtrue" ]; then \
 		cd subprojects/urllib3 && \
@@ -112,10 +107,6 @@ umu-vendored-install: umu-vendored
 	@if [ "$(USE_SYSTEM_PYZSTD)" != "xtrue" ]; then \
 		$(PYTHON_INTERPRETER) -m installer --destdir=$(DESTDIR)$(PYTHONDIR)/umu/_vendor subprojects/pyzstd/$(OBJDIR)/pyzstd*.whl; \
 		find $(DESTDIR)$(PYTHONDIR)/umu/_vendor -type d -name pyzstd | xargs -I {} mv {} $(DESTDIR)$(PYTHONDIR)/umu/_vendor; \
-	fi
-	@if [ "$(USE_SYSTEM_VDF)" != "xtrue" ]; then \
-		$(PYTHON_INTERPRETER) -m installer --destdir=$(DESTDIR)$(PYTHONDIR)/umu/_vendor subprojects/vdf/$(OBJDIR)/vdf*.whl; \
-		find $(DESTDIR)$(PYTHONDIR)/umu/_vendor -type d -name vdf | xargs -I {} mv {} $(DESTDIR)$(PYTHONDIR)/umu/_vendor; \
 	fi
 	@if [ "$(USE_SYSTEM_URLLIB)" != "xtrue" ]; then \
 		$(PYTHON_INTERPRETER) -m installer --destdir=$(DESTDIR)$(PYTHONDIR)/umu/_vendor subprojects/urllib3/$(OBJDIR)/urllib3*.whl; \

--- a/README.md
+++ b/README.md
@@ -88,8 +88,7 @@ Borderlands 3 from EGS store.
 
 When reporting issues for games that fail to run, be sure to attach a log with your issue report. To acquire a log from umu, add `UMU_LOG=1` to your environment variables for verbose logging. Furthermore, you can use `PROTON_LOG=1` for proton to create a verbose log in your `$HOME` directory. The log will be named `steam-<appid>.log`, where `<appid>` will be `default` if you haven't set a `GAMEID` or a number, depending on what you have set for `GAMEID`.
 
-Do **NOT** report issues when using `UMU_NO_RUNTIME=1`, this option is provided for convenience for compatibility tools that do not set their runtime requirements, such as Proton < `5.13`, and they do not work with any of the supported runtimes.
-This mode does not make use of a container runtime, and issues while using it are irrelevant to umu-launcher in general. Thus such issues will be automatically closed.
+Do **NOT** report issues here when using compatibility tools that are **NOT** explictly supported, report them to their maintainers first. This includes non-Proton compatibility tools, as well as third-party Proton compatibility tools that are not provided through `umu-launcher`.
 
 ## Building
 

--- a/configure.sh
+++ b/configure.sh
@@ -75,9 +75,6 @@ function configure() {
     if [[ -n "$arg_use_system_urllib" ]]; then
       echo "USE_SYSTEM_URLLIB := xtrue"
     fi
-    if [[ -n "$arg_use_system_vdf" ]]; then
-      echo "USE_SYSTEM_VDF := xtrue"
-    fi
 
     # Prefix was specified, baking it into the Makefile
     if [[ -n $arg_prefix ]]; then
@@ -101,7 +98,6 @@ arg_user_install=""
 arg_help=""
 arg_use_system_pyzstd=""
 arg_use_system_urllib=""
-arg_use_system_vdf=""
 function parse_args() {
   local arg;
   local val;
@@ -151,8 +147,6 @@ function parse_args() {
       arg_use_system_pyzstd="1"
     elif [[ $arg = --use-system-urllib ]]; then
       arg_use_system_urllib="1"
-    elif [[ $arg = --use-system-vdf ]]; then
-      arg_use_system_vdf="1"
     else
       err "Unrecognized option $arg"
       return 1

--- a/docs/umu.1.scd
+++ b/docs/umu.1.scd
@@ -186,13 +186,6 @@ _UMU_HTTP_RETRIES_
 
 	Set _0_ to disable retries for HTTP requests. Set a positive integer to override the default.
 
-_UMU_NO_RUNTIME_
-	Optional. Allows for the configured compatibility tool to run outside of the Steam Linux Runtime.
-	This option is effective only if the compatibility tool doesn't require a runtime through its configuration.
-	On compatibility tools that require a runtime, this option is ignored.
-
-	Set _1_ to silence umu's error that it couldn't resolve a runtime to use, and run using the host's libraries.
-
 # SEE ALSO
 
 _umu_(5), _winetricks_(1)

--- a/packaging/nix/unwrapped.nix
+++ b/packaging/nix/unwrapped.nix
@@ -2,7 +2,6 @@
   # Dependencies
   lib,
   rustPlatform,
-  python3Packages,
   umu-launcher-unwrapped,
   version,
   # Freeform overrides
@@ -20,7 +19,6 @@ assert lib.assertMsg (lib.versionAtLeast umu-launcher-unwrapped.version "1.2.0")
   overrideArgs = builtins.removeAttrs args [
     "lib"
     "rustPlatform"
-    "python3Packages"
     "umu-launcher-unwrapped"
     "version"
   ];
@@ -32,24 +30,12 @@ assert lib.assertMsg (lib.versionAtLeast umu-launcher-unwrapped.version "1.2.0")
     then umu-launcher-unwrapped
     else umu-launcher-unwrapped.override overrideArgs;
 in
-  package.overridePythonAttrs (old: {
+  package.overridePythonAttrs {
     inherit version;
     src = ../../.;
     cargoDeps = rustPlatform.importCargoLock {
       lockFile = ../../Cargo.lock;
     };
-
-    pythonPath =
-      (old.pythonPath or [])
-      ++ [
-        python3Packages.vdf
-      ];
-
-    configureFlags =
-      (old.configureFlags or [])
-      ++ [
-        "--use-system-vdf"
-      ];
 
     # Specify ourselves which tests are disabled
     disabledTests = [
@@ -61,14 +47,5 @@ in
       # Broken? Tests parse_args with no options (./umu_run.py)
       # Fails with AssertionError: SystemExit not raised
       "test_parse_args_noopts"
-
-      # FileNotFoundError: [Errno 2] No such file or directory: .local/share/umu/toolmanifest.vdf
-      "test_build_command"
-      "test_build_command_linux_exe"
-      "test_build_command_nopv"
-
-      # TypeError: cannot unpack non-iterable ThreadPoolExecutor object
-      "test_env_nowine_noproton"
-      "test_env_wine_noproton"
     ];
-  })
+  }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 urls = { repository = "https://github.com/Open-Wine-Components/umu-launcher" }
 # Note: urllib3 is a vendored dependency. When using our Makefile, it will be
 # installed automatically.
-dependencies = ["python-xlib>=0.33", "urllib3>=2.0.0", "vdf>=3.4"]
+dependencies = ["python-xlib>=0.33", "urllib3>=2.0.0"]
 
 [project.optional-dependencies]
 # Recommended

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,5 @@
 python-xlib>=0.33
 urllib3>=2.0.0,<3.0.0
-vdf>=3.4
 xxhash>=3.2.0
 pyzstd>=0.16.2
 cbor2>=5.4.6

--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -56,6 +56,7 @@ class ProtonVersion(Enum):
     UMUScout = "umu-scout"
     UMUSoldier = "umu-soldier"
     UMUSniper = "umu-sniper"
+    UMUSniper_arm64 = "umu-sniper-arm64"
     UMUSteamRT4 = "umu-steamrt4"
 
 
@@ -114,6 +115,7 @@ def _get_umu_runtime_tool(env: dict[str, str], name: str) -> dict[str, str] | No
     if not (name and name in {
         ProtonVersion.UMUSoldier.value,
         ProtonVersion.UMUSniper.value,
+        ProtonVersion.UMUSniper_arm64.value,
         ProtonVersion.UMUSteamRT4.value
     }):
         return None

--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -240,7 +240,7 @@ def _fetch_releases(
     }:
         repo = "/repos/GloriousEggroll/proton-ge-custom/releases/latest"
 
-    if os.environ.get("PROTONPATH") in {ProtonVersion.UMUScout.value}:
+    if os.environ.get("PROTONPATH") == ProtonVersion.UMUScout.value:
         repo = "/repos/loathingKernel/umu-scout/releases/latest"
 
     resp = http_pool.request(HTTPMethod.GET.value, f"{url}{repo}", headers=headers)

--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -14,11 +14,11 @@ from shutil import move
 from tempfile import TemporaryDirectory, mkdtemp
 from typing import Any
 
-import vdf
 from urllib3.exceptions import HTTPError
 from urllib3.poolmanager import PoolManager
 from urllib3.response import BaseHTTPResponse
 
+from umu import vdf
 from umu.umu_bspatch import Content, ContentContainer, CustomPatcher
 from umu.umu_consts import (
     STEAM_COMPAT,

--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -58,6 +58,7 @@ class ProtonVersion(Enum):
     UMUSniper = "umu-sniper"
     UMUSniper_arm64 = "umu-sniper-arm64"
     UMUSteamRT4 = "umu-steamrt4"
+    UMUSteamRT4_arm64 = "umu-steamrt4-arm64"
 
 
 def get_umu_proton(env: dict[str, str], session_pools: SessionPools) -> dict[str, str]:
@@ -116,7 +117,8 @@ def _get_umu_runtime_tool(env: dict[str, str], name: str) -> dict[str, str] | No
         ProtonVersion.UMUSoldier.value,
         ProtonVersion.UMUSniper.value,
         ProtonVersion.UMUSniper_arm64.value,
-        ProtonVersion.UMUSteamRT4.value
+        ProtonVersion.UMUSteamRT4.value,
+        ProtonVersion.UMUSteamRT4_arm64.value,
     }):
         return None
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -738,7 +738,7 @@ def resolve_runtime() -> RuntimeVersion | None:
 
     toolmanifest = path.joinpath("toolmanifest.vdf")
     if toolmanifest.is_file():
-        layer = CompatLayer(toolmanifest.parent, Path())
+        layer = CompatLayer(toolmanifest.parent, Path(), resolve=False)
         runtime = layer.required_runtime
     else:
         err: str = f"PROTONPATH '{os.environ['PROTONPATH']}' is not valid, toolmanifest.vdf not found"
@@ -914,7 +914,7 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
             create_shim(UMU_LOCAL / "umu-shim")
 
         protonpath: Path = Path(env["PROTONPATH"]).expanduser().resolve(strict=True)
-        layer = CompatLayer(protonpath, UMU_LOCAL.joinpath("umu-shim"))
+        layer = CompatLayer(protonpath, UMU_LOCAL.joinpath("umu-shim"), resolve=True)
 
         # Prepare the prefix
         if layer.is_proton:

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -149,7 +149,11 @@ def check_env(env: dict[str, str]) -> tuple[dict[str, str] | dict[str, Any], boo
 
     # Proton Codename
     if os.environ.get("PROTONPATH") in {
-        "GE-Proton", "GE-Latest", "UMU-Latest", "umu-scout", "umu-soldier", "umu-sniper", "umu-steamrt4"
+        "GE-Proton", "GE-Latest", "UMU-Latest",
+        "umu-scout",
+        "umu-soldier",
+        "umu-sniper", "umu-sniper-arm64",
+        "umu-steamrt4"
     }:
         do_download = True
 
@@ -708,6 +712,7 @@ def resolve_runtime() -> RuntimeVersion | None:
     named_runtimes = {
         RUNTIME_NAMES["steamrt4"]: {"umu-steamrt4"},
         RUNTIME_NAMES["sniper"]: {"GE-Proton", "GE-Latest", "UMU-Latest", "umu-sniper"},
+        RUNTIME_NAMES["sniper-arm64"]: {"umu-sniper-arm64"},
         RUNTIME_NAMES["soldier"]: {"umu-scout", "umu-soldier"},
     }
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -64,7 +64,13 @@ RuntimeVersion = tuple[str, str, str]
 
 
 def setup_pfx(path: Path) -> None:
-    """Prepare a Proton compatible WINE prefix."""
+    """Prepare a Proton compatible WINE prefix.
+
+    `path` needs to be fully resolved before setup_pfx
+    """
+    if not path.is_absolute():
+        path = path.expanduser().resolve(strict=False)
+
     if not path.is_dir():
         path.mkdir(parents=True, exist_ok=True)
 
@@ -120,11 +126,12 @@ def check_env(env: dict[str, str]) -> tuple[dict[str, str] | dict[str, Any], boo
             pfx: Path = Path.home().joinpath("Games", env["STORE"])
         else:
             pfx: Path = Path.home().joinpath("Games", "umu", env["GAMEID"])
+        pfx = pfx.resolve(strict=False)
     else:
-        pfx: Path = Path(os.environ["WINEPREFIX"]).expanduser()
+        pfx: Path = Path(os.environ["WINEPREFIX"]).expanduser().resolve(strict=False)
 
     if not pfx.is_absolute():
-        err: str = "WINEPREFIX is set but not an absolute path."
+        err: str = f"WINEPREFIX is set but not an absolute path: {pfx}."
         raise RuntimeError(err)
 
     os.environ["WINEPREFIX"] = str(pfx)

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -340,7 +340,7 @@ def build_command(
         # The position of arguments matter for winetricks
         # Usage: ./winetricks [options] [command|verb|path-to-verb] ...
         return (
-            *layer.command(env["PROTON_VERB"]),
+            *layer.command(env["PROTON_VERB"], unwrapped=False),
             env["EXE"],
             "-q",
             *opts,
@@ -360,15 +360,13 @@ def build_command(
         pfx_bus = "com.steampowered.App" + env["STEAM_COMPAT_APP_ID"]
         if f"--bus-name={pfx_bus}" in bus_names:
             nsenter = (launch_client, f"--bus-name={pfx_bus}", "--")
-            # Unset runtime to make the CompatLayer stack report only the command
-            # of the innermost layer instead of the whole layer chain.
-            layer.runtime = None
             env["PROTON_VERB"] = "runinprefix"
             log.info("Re-entering container through bus '%s'", pfx_bus)
 
+    is_nsenter: bool = bool(nsenter)
     return (
         *nsenter,
-        *layer.command(env["PROTON_VERB"]),
+        *layer.command(env["PROTON_VERB"], unwrapped=is_nsenter),
         env["EXE"],
         *opts,
     )

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -365,8 +365,6 @@ def build_command(
             layer.runtime = None
             env["PROTON_VERB"] = "runinprefix"
             log.info("Re-entering container through bus '%s'", pfx_bus)
-        else:
-            env["PROTON_VERB"] = "waitforexitandrun"
 
     return (
         *nsenter,
@@ -923,7 +921,7 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
                 setup_pfx(cdata_path)
 
         # Configure the environment
-        env["STEAM_COMPAT_LAUNCHER_SERVICE"] = layer.layer_name
+        env["STEAM_COMPAT_LAUNCHER_SERVICE"] = layer.launcher_service
         set_env(env, args)
 
         # Set all environment variables

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -321,20 +321,6 @@ def build_command(
     if opts is None:
         opts = []
 
-    # if env.get("UMU_NO_PROTON") != "1" and not proton.is_file():
-    #     err: str = "The following file was not found in PROTONPATH: proton"
-    #     raise FileNotFoundError(err)
-    #
-    # # Exit if the entry point is missing
-    # # The _v2-entry-point script and container framework tools are included in
-    # # the same image, so this can happen if the image failed to download
-    # if entry_point and not entry_point[0].is_file():
-    #     err: str = (
-    #         f"_v2-entry-point (umu) cannot be found in '{local}'\n"
-    #         "Runtime Platform missing or download incomplete"
-    #     )
-    #     raise FileNotFoundError(err)
-
     # Winetricks
     if layer.is_proton and env.get("EXE", "").endswith("winetricks") and opts:
         # The position of arguments matter for winetricks
@@ -345,12 +331,6 @@ def build_command(
             "-q",
             *opts,
         )
-
-    # # Will run the game within the Steam Runtime w/o Proton
-    # # Ideally, for reliability, executables should be compiled within
-    # # the Steam Runtime
-    # if env.get("UMU_NO_PROTON") == "1":
-    #     return *entry_point, env["EXE"], *opts
 
     nsenter: tuple[str, ...] = ()
     if launch_client := layer.launch_client:

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -153,7 +153,7 @@ def check_env(env: dict[str, str]) -> tuple[dict[str, str] | dict[str, Any], boo
         "umu-scout",
         "umu-soldier",
         "umu-sniper", "umu-sniper-arm64",
-        "umu-steamrt4"
+        "umu-steamrt4", "umu-steamrt4-arm64",
     }:
         do_download = True
 
@@ -711,6 +711,7 @@ def resolve_runtime() -> RuntimeVersion | None:
 
     named_runtimes = {
         RUNTIME_NAMES["steamrt4"]: {"umu-steamrt4"},
+        RUNTIME_NAMES["steamrt4-arm64"]: {"umu-steamrt4-arm64"},
         RUNTIME_NAMES["sniper"]: {"GE-Proton", "GE-Latest", "UMU-Latest", "umu-sniper"},
         RUNTIME_NAMES["sniper-arm64"]: {"umu-sniper-arm64"},
         RUNTIME_NAMES["soldier"]: {"umu-scout", "umu-soldier"},

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -121,8 +121,14 @@ def check_env(env: dict[str, str]) -> tuple[dict[str, str] | dict[str, Any], boo
         err: str = "Environment variable is empty: WINEPREFIX"
         raise ValueError(err)
 
+    env["STORE"] = os.environ.get("STORE", "")
     if "WINEPREFIX" not in os.environ:
-        if "STORE" in os.environ:
+        # Do not use the per-store prefix path in case STORE is either an empty string or "none"
+        # The "none" special case is here to work-around Lutris's defaults
+        # https://github.com/lutris/lutris/blob/2c3b3e0d543ec736df7dd2c313bd471ce8d77c33/lutris/game.py#L672-L678
+        # which caused the default prefix to use an unexpected path in some cases
+        # https://github.com/CachyOS/CachyOS-PKGBUILDS/issues/1124
+        if "STORE" in os.environ and env["STORE"] not in {"", "none"}:
             pfx: Path = Path.home().joinpath("Games", env["STORE"])
         else:
             pfx: Path = Path.home().joinpath("Games", "umu", env["GAMEID"])

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -691,6 +691,16 @@ def run_command(command: tuple[Path | str, ...]) -> int:
 
 def resolve_runtime() -> RuntimeVersion | None:
     """Resolve the required runtime of a compatibility tool."""
+    # Backwards compatibility stuff, map RUNTIMEPATH tokens to
+    # umu's passthrough compatibility layers for runtimes.
+    runtimepath_compat = {
+        "steamrt2": "umu-soldier",
+        "steamrt3": "umu-sniper",
+        "steamrt4": "umu-steamrt4",
+    }
+    if os.environ.get("RUNTIMEPATH") and (os.environ.get("UMU_NO_PROTON") or not os.environ.get("PROTONPATH")):
+        os.environ["PROTONPATH"] = runtimepath_compat[os.environ.get("RUNTIMEPATH", "")]
+
     # default to UMU-Latest if PROTONPATH is not set
     if not os.environ.get("PROTONPATH"):
         os.environ["PROTONPATH"] = "UMU-Latest"

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -316,7 +316,7 @@ def build_command(
     env: dict[str, str],
     layer: CompatLayer,
     opts: list[str] | None = None,
-) -> tuple[Path | str, ...]:
+) -> tuple[str, ...]:
     """Build the command to be executed."""
     if opts is None:
         opts = []
@@ -714,7 +714,7 @@ def resolve_runtime() -> RuntimeVersion | None:
 
     toolmanifest = path.joinpath("toolmanifest.vdf")
     if toolmanifest.is_file():
-        layer = CompatLayer(toolmanifest.parent, Path(), resolve=False)
+        layer = CompatLayer(toolmanifest.parent, Path())
         runtime = layer.required_runtime
     else:
         err: str = f"PROTONPATH '{os.environ['PROTONPATH']}' is not valid, toolmanifest.vdf not found"
@@ -890,7 +890,7 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
             create_shim(UMU_LOCAL / "umu-shim")
 
         protonpath: Path = Path(env["PROTONPATH"]).expanduser().resolve(strict=True)
-        layer = CompatLayer(protonpath, UMU_LOCAL.joinpath("umu-shim"), resolve=True)
+        layer = CompatLayer(protonpath, UMU_LOCAL.joinpath("umu-shim"))
 
         # Prepare the prefix
         if layer.is_proton:
@@ -915,7 +915,7 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
         sys.exit(1)
 
     # Build the command
-    command: tuple[Path | str, ...] = build_command(env, layer, opts)
+    command: tuple[str, ...] = build_command(env, layer, opts)
     log.debug("%s", command)
 
     # Run the command

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -123,12 +123,7 @@ def check_env(env: dict[str, str]) -> tuple[dict[str, str] | dict[str, Any], boo
 
     env["STORE"] = os.environ.get("STORE", "")
     if "WINEPREFIX" not in os.environ:
-        # Do not use the per-store prefix path in case STORE is either an empty string or "none"
-        # The "none" special case is here to work-around Lutris's defaults
-        # https://github.com/lutris/lutris/blob/2c3b3e0d543ec736df7dd2c313bd471ce8d77c33/lutris/game.py#L672-L678
-        # which caused the default prefix to use an unexpected path in some cases
-        # https://github.com/CachyOS/CachyOS-PKGBUILDS/issues/1124
-        if "STORE" in os.environ and env["STORE"] not in {"", "none"}:
+        if "STORE" in os.environ and bool(env["STORE"]):
             pfx: Path = Path.home().joinpath("Games", env["STORE"])
         else:
             pfx: Path = Path.home().joinpath("Games", "umu", env["GAMEID"])

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -449,10 +449,12 @@ class UmuRuntime:
 
 
 RUNTIME_VERSIONS = {
-    "host":    UmuRuntime("host",    ""        , ""   ),
-    "1391110": UmuRuntime("soldier", "steamrt2", "1391110"),
-    "1628350": UmuRuntime("sniper",  "steamrt3", "1628350"),
-    "4183110": UmuRuntime("steamrt4","steamrt4", "4183110"),
+    "host": UmuRuntime("host", "", ""),
+    "1391110": UmuRuntime("soldier",      "steamrt2", "1391110"),
+    "1628350": UmuRuntime("sniper",       "steamrt3", "1628350"),
+    "3810310": UmuRuntime("sniper-arm64", "steamrt3", "3810310"),
+    "4183110": UmuRuntime("steamrt4",     "steamrt4", "4183110"),
+    # "4183110": UmuRuntime("steamrt4-arm64", "steamrt4", "4183110"),
 }
 
 

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -499,15 +499,20 @@ class CompatLayer:
 
     @property
     def layer_name(self) -> str:  # noqa: D102
-        layer_name = str(ret) if (ret := self.tool_manifest.get("compatmanager_layer_name")) else ""
-        if layer_name == "umu-passthrough" and self.runtime is not None:
-            layer_name = self.runtime.tool_manifest.get("compatmanager_layer_name")
-        return layer_name
+        return str(ret) if (ret := self.tool_manifest.get("compatmanager_layer_name")) else ""
+
+    @property
+    def launcher_service(self) -> str:
+        """Report the correct layer name for STEAM_COMPAT_LAUNCER_SERVICE."""
+        service = self.layer_name
+        if service == "umu-passthrough" and self.runtime is not None:
+            service = self.runtime.launcher_service
+        return service
 
     @property
     def launch_client(self) -> str | None:
         """Expose pv's launch-client path depending on the tool's container runtime."""
-        if self.tool_manifest.get("compatmanager_layer_name") == "container-runtime":
+        if self.layer_name == "container-runtime":
             return f"{self.tool_path}/pressure-vessel/bin/steam-runtime-launch-client"
         if self.runtime:
             return self.runtime.launch_client

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -76,7 +76,7 @@ def _install_umu(
     ret: int = 0  # Exit code from zenity
     thread_pool, http_pool = session_pools
     codename, variant, _ = runtime_ver
-    base_url: str = f"https://repo.steampowered.com/{variant}/images/latest-public-beta"
+    base_url: str = f"https://repo.steampowered.com/{variant.removesuffix('-arm64')}/images/latest-public-beta/"
     token: str = f"?versions={token_urlsafe(16)}"
     host: str = "repo.steampowered.com"
 
@@ -110,7 +110,7 @@ def _install_umu(
     if not os.environ.get("UMU_ZENITY") or ret:
         digest: str = ""
         buildid: str = ""
-        endpoint: str = f"/{variant}/images/latest-public-beta"
+        endpoint: str = f"/{variant.removesuffix('-arm64')}/images/latest-public-beta"
         hashsum = sha256()
         headers: dict[str, str] | None = None
         cached_parts: Path
@@ -272,7 +272,7 @@ def _update_umu(
     resp: BaseHTTPResponse
     _, http_pool = session_pools
     codename, variant, _ = runtime_ver
-    endpoint: str = f"/{variant}/images/latest-public-beta"
+    endpoint: str = f"/{variant.removesuffix('-arm64')}/images/latest-public-beta"
     # Create a token and append it to the URL to avoid the Cloudflare cache
     # Avoids infinite updates to the runtime each launch
     # See https://github.com/Open-Wine-Components/umu-launcher/issues/188
@@ -456,11 +456,11 @@ RUNTIME_VERSIONS = {
 }
 
 RUNTIME_VERSIONS.update({
-    "1391110": UmuRuntime("soldier",        "steamrt2", "1391110"),
-    "1628350": UmuRuntime("sniper",         "steamrt3", "1628350"),
-    "3810310": UmuRuntime("sniper-arm64",   "steamrt3", "3810310"),
-    "4183110": UmuRuntime("steamrt4",       "steamrt4", "4183110"),
-    "4185400": UmuRuntime("steamrt4-arm64", "steamrt4", "4185400"),
+    "1391110": UmuRuntime("soldier",        "steamrt2",       "1391110"),
+    "1628350": UmuRuntime("sniper",         "steamrt3",       "1628350"),
+    "3810310": UmuRuntime("sniper-arm64",   "steamrt3-arm64", "3810310"),
+    "4183110": UmuRuntime("steamrt4",       "steamrt4",       "4183110"),
+    "4185400": UmuRuntime("steamrt4-arm64", "steamrt4-arm64", "4185400"),
 })
 
 if platform.machine() == "x86_64":  # noqa: SIM114

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -80,7 +80,7 @@ def _install_umu(
     token: str = f"?versions={token_urlsafe(16)}"
     host: str = "repo.steampowered.com"
 
-    if codename.removeprefix("steamrt").isdigit():
+    if codename.removeprefix("steamrt").removesuffix("-arm64").isdigit():
         archive = f"SteamLinuxRuntime_{codename.removeprefix('steamrt')}.tar.xz"
     else:
         archive = f"SteamLinuxRuntime_{codename}.tar.xz"

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -11,11 +11,11 @@ from shutil import move
 from subprocess import run
 from tempfile import TemporaryDirectory, mkdtemp
 
-import vdf
 from urllib3.exceptions import HTTPError
 from urllib3.poolmanager import PoolManager
 from urllib3.response import BaseHTTPResponse
 
+from umu import vdf
 from umu.umu_consts import UMU_CACHE, UMU_LOCAL, FileLock, HTTPMethod
 from umu.umu_log import log
 from umu.umu_util import (

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -284,17 +284,17 @@ def _update_umu(
 
     # Find the runtime directory (e.g., sniper_platform_0.20240530.90143)
     # Assume the directory begins with the variant
-    codename = codename.removesuffix("-arm64")
+    _codename = codename.removesuffix("-arm64")
     try:
-        max(file for file in local.glob(f"{codename}*") if file.is_dir())
+        max(file for file in local.glob(f"{_codename}_platform_*") if file.is_dir())
     except ValueError:
-        log.critical("*_platform_* directory missing in '%s'", local)
+        log.critical("%s_platform_* directory missing in '%s'", _codename, local)
         log.info("Restoring Runtime Platform...")
         _restore_umu(
             local,
             runtime_ver,
             session_pools,
-            lambda: len([file for file in local.glob(f"{codename}*") if file.is_dir()])
+            lambda: len([file for file in local.glob(f"{_codename}_platform_*") if file.is_dir()])
             > 0,
         )
         return
@@ -350,12 +350,12 @@ def check_runtime(src: Path, runtime_ver: RuntimeVersion) -> int:
     ret: int = 1
 
     # Find the runtime directory
-    codename = codename.removesuffix("-arm64")
+    _codename = codename.removesuffix("-arm64")
     try:
-        runtime = max(file for file in src.glob(f"{codename}*") if file.is_dir())
+        runtime = max(file for file in src.glob(f"{_codename}_platform_*") if file.is_dir())
     except ValueError:
         log.critical("%s validation failed", variant)
-        log.critical("Could not find *_platform_* in '%s'", src)
+        log.critical("Could not find %s_platform_* in '%s'", _codename, src)
         return ret
 
     if not pv_verify.is_file():

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -284,6 +284,7 @@ def _update_umu(
 
     # Find the runtime directory (e.g., sniper_platform_0.20240530.90143)
     # Assume the directory begins with the variant
+    codename = codename.removesuffix("-arm64")
     try:
         max(file for file in local.glob(f"{codename}*") if file.is_dir())
     except ValueError:
@@ -349,6 +350,7 @@ def check_runtime(src: Path, runtime_ver: RuntimeVersion) -> int:
     ret: int = 1
 
     # Find the runtime directory
+    codename = codename.removesuffix("-arm64")
     try:
         runtime = max(file for file in src.glob(f"{codename}*") if file.is_dir())
     except ValueError:

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import shlex
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
@@ -450,12 +451,23 @@ class UmuRuntime:
 
 RUNTIME_VERSIONS = {
     "host": UmuRuntime("host", "", ""),
-    "1391110": UmuRuntime("soldier",      "steamrt2", "1391110"),
-    "1628350": UmuRuntime("sniper",       "steamrt3", "1628350"),
-    "3810310": UmuRuntime("sniper-arm64", "steamrt3", "3810310"),
-    "4183110": UmuRuntime("steamrt4",     "steamrt4", "4183110"),
-    # "4183110": UmuRuntime("steamrt4-arm64", "steamrt4", "4183110"),
 }
+
+RUNTIME_VERSIONS.update({
+    "1391110": UmuRuntime("soldier",        "steamrt2", "1391110"),
+    "1628350": UmuRuntime("sniper",         "steamrt3", "1628350"),
+    "3810310": UmuRuntime("sniper-arm64",   "steamrt3", "3810310"),
+    "4183110": UmuRuntime("steamrt4",       "steamrt4", "4183110"),
+    "4185400": UmuRuntime("steamrt4-arm64", "steamrt4", "4185400"),
+})
+
+if platform.machine() == "x86_64":  # noqa: SIM114
+    pass
+elif platform.machine() == "aarch64":
+    pass
+else:
+    err: str = f"Unsupported platform {platform.machine()}"
+    raise RuntimeError(err)
 
 
 RUNTIME_NAMES = {RUNTIME_VERSIONS[key].name: key for key in RUNTIME_VERSIONS}

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -567,7 +567,7 @@ class CompatLayer:
         tool_path = os.path.normpath(self.tool_path)
         cmd = "".join([shlex.quote(tool_path), self.tool_manifest["commandline"]])
         # Temporary override entry point for backwards compatibility
-        if self.layer_name in {"container-runtime"}:
+        if self.layer_name == "container-runtime":
             cmd = cmd.replace("_v2-entry-point", "umu")
         cmd = cmd.replace("%verb%", verb)
         return shlex.split(cmd)
@@ -580,7 +580,7 @@ class CompatLayer:
         log.info("Running '%s' using runtime '%s'", self.display_name, self.required_runtime.name)
         cmd = self.runtime.command(verb, unwrapped=False) if self.runtime is not None else []
         target = self._unwrapped_cmd(verb)
-        if self.layer_name in {"container-runtime"}:
+        if self.layer_name == "container-runtime":
             cmd.extend([*target, self._shim.as_posix()])
         elif self.runtime is None:
             cmd.extend([self._shim.as_posix(), *target])

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -1932,7 +1932,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = self.test_file
             os.environ["PROTONPATH"] = "GE-Proton"
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, self.test_session_pools)
+            umu_run.download_proton(result_env, self.test_session_pools, download=result_dl)
             self.assertEqual(
                 self.env["PROTONPATH"],
                 self.test_compat.joinpath(
@@ -1960,7 +1960,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = self.test_file
             os.environ["PROTONPATH"] = "GE-Proton"
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, mock_session_pools)
+            umu_run.download_proton(result_env, mock_session_pools, download=result_dl)
             self.assertFalse(os.environ.get("PROTONPATH"), "Expected empty string")
 
     def test_latest_interrupt(self):
@@ -2324,7 +2324,7 @@ class TestGameLauncher(unittest.TestCase):
             args = __main__.parse_args()
             # Config
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
             # Prefix
             umu_run.setup_pfx(Path(self.env["WINEPREFIX"]))
             # Env
@@ -2422,7 +2422,7 @@ class TestGameLauncher(unittest.TestCase):
             args = __main__.parse_args()
             # Config
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
             # Prefix
             umu_run.setup_pfx(Path(self.env["WINEPREFIX"]))
             # Env
@@ -2515,7 +2515,7 @@ class TestGameLauncher(unittest.TestCase):
             ):
                 self.env = umu_proton._get_umu_runtime_tool(self.env, self.env["PROTONPATH"])
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
             # Prefix
             umu_run.setup_pfx(Path(self.env["WINEPREFIX"]))
             # Env
@@ -2637,7 +2637,7 @@ class TestGameLauncher(unittest.TestCase):
             # Config
             _, result_dl = umu_run.check_env(self.env)
             if version[1]:
-                umu_run.download_proton(result_dl, self.env, thread_pool)
+                umu_run.download_proton(self.env, thread_pool, download=result_dl)
             # Prefix
             umu_run.setup_pfx(Path(self.env["WINEPREFIX"]))
             # Env
@@ -2753,7 +2753,7 @@ class TestGameLauncher(unittest.TestCase):
             # Config
             _, result_dl = umu_run.check_env(self.env)
             if version[1]:
-                umu_run.download_proton(result_dl, self.env, thread_pool)
+                umu_run.download_proton(self.env, thread_pool, download=result_dl)
             # Prefix
             umu_run.setup_pfx(Path(self.env["WINEPREFIX"]))
             # Env
@@ -2813,7 +2813,6 @@ class TestGameLauncher(unittest.TestCase):
         self.assertEqual(verb, "waitforexitandrun", "Expected PROTON_VERB")
         self.assertEqual(exe, self.env["EXE"], "Expected EXE")
 
-
     def test_build_command_noproton(self):
         """Test build_command when $PROTONPATH/proton is not found.
 
@@ -2835,7 +2834,7 @@ class TestGameLauncher(unittest.TestCase):
             result_args = __main__.parse_args()
             # Config
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
             # Prefix
             umu_run.setup_pfx(Path(self.env["WINEPREFIX"]))
             # Env
@@ -2884,7 +2883,7 @@ class TestGameLauncher(unittest.TestCase):
             result_args = __main__.parse_args()
             # Config
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
             # Prefix
             umu_run.setup_pfx(Path(self.env["WINEPREFIX"]))
             # Env
@@ -2990,7 +2989,7 @@ class TestGameLauncher(unittest.TestCase):
             result = __main__.parse_args()
             # Check
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
             # Prefix
             umu_run.setup_pfx(Path(self.env["WINEPREFIX"]))
 
@@ -3072,7 +3071,7 @@ class TestGameLauncher(unittest.TestCase):
             result = __main__.parse_args()
             # Check
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
             # Prefix
             umu_run.setup_pfx(Path(self.env["WINEPREFIX"]))
             # Env
@@ -3176,7 +3175,7 @@ class TestGameLauncher(unittest.TestCase):
             result = __main__.parse_args()
             # Check
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
             # Prefix
             umu_run.setup_pfx(Path(self.env["WINEPREFIX"]))
             # Env
@@ -3288,7 +3287,7 @@ class TestGameLauncher(unittest.TestCase):
             result = __main__.parse_args()
             # Check
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
             # Prefix
             umu_run.setup_pfx(Path(self.env["WINEPREFIX"]))
             # Env
@@ -3416,7 +3415,7 @@ class TestGameLauncher(unittest.TestCase):
             result = __main__.parse_args()
             # Check
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
             # Prefix
             umu_run.setup_pfx(Path(self.env["WINEPREFIX"]))
             # Env
@@ -3955,7 +3954,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["WINEPREFIX"] = self.test_file
             os.environ["GAMEID"] = self.test_file
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
 
     def test_env_wine_empty(self):
         """Test check_env when $WINEPREFIX is empty.
@@ -3972,7 +3971,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["WINEPREFIX"] = ""
             os.environ["GAMEID"] = self.test_file
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
 
     def test_env_gameid_empty(self):
         """Test check_env when $GAMEID is empty.
@@ -3989,7 +3988,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["WINEPREFIX"] = ""
             os.environ["GAMEID"] = ""
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
 
     def test_env_wine_dir(self):
         """Test check_env when $WINEPREFIX is not a directory.
@@ -4011,7 +4010,7 @@ class TestGameLauncher(unittest.TestCase):
 
         with ThreadPoolExecutor() as thread_pool:
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
 
         # After this, the WINEPREFIX and new dirs should be created
         # Update; the prefix is created in setup_pfx
@@ -4048,7 +4047,7 @@ class TestGameLauncher(unittest.TestCase):
 
         with ThreadPoolExecutor() as thread_pool:
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
 
         self.assertTrue(result_env is self.env, "Expected the same reference")
         self.assertEqual(
@@ -4074,7 +4073,7 @@ class TestGameLauncher(unittest.TestCase):
 
         with ThreadPoolExecutor() as thread_pool:
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
 
         self.assertTrue(result_env is self.env, "Expected the same reference")
         self.assertEqual(
@@ -4108,7 +4107,7 @@ class TestGameLauncher(unittest.TestCase):
                 os.environ["WINEPREFIX"] = self.test_file
                 os.environ["GAMEID"] = self.test_file
                 result_env, result_dl = umu_run.check_env(self.env)
-                umu_run.download_proton(result_dl, result_env, thread_pool)
+                umu_run.download_proton(result_env, thread_pool, download=result_dl)
                 self.assertTrue(result_env is self.env, "Expected the same reference")
                 self.assertFalse(os.environ["PROTONPATH"])
 

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -30,7 +30,7 @@ from Xlib.xobject.drawable import Window
 
 sys.path.append(str(Path(__file__).parent.parent))
 
-from umu import __main__, umu_proton, umu_run, umu_runtime, umu_util
+from umu import __main__, umu_proton, umu_run, umu_runtime, umu_util, vdf
 
 
 class TestGameLauncher(unittest.TestCase):
@@ -91,7 +91,7 @@ class TestGameLauncher(unittest.TestCase):
         # umu compat dir
         self.test_umu_compat = Path("./tmp.tu692WxQHH")
         # umu-proton dir
-        self.test_proton_dir = Path("UMU-Proton-5HYdpddgvs")
+        self.test_proton_dir = Path("./UMU-Proton-5HYdpddgvs")
         # umu-proton release
         self.test_archive = Path(self.test_cache).joinpath(
             f"{self.test_proton_dir}.tar.gz"
@@ -142,14 +142,55 @@ class TestGameLauncher(unittest.TestCase):
         Path(self.test_user_share, "run").touch()
         Path(self.test_user_share, "run-in-sniper").touch()
         Path(self.test_user_share, "umu").touch()
+        mock_steamrt_toolmanifest = {
+            "manifest": {
+                "commandline": "/_v2-entry-point --verb=%verb% --",
+                "filter_exclusive_priority": "3",
+                "version": "2",
+                "use_tool_subprocess_reaper": "1",
+                "compatmanager_layer_name": "container-runtime",
+            }
+        }
+        Path(self.test_user_share, "toolmanifest.vdf").write_text(vdf.dumps(mock_steamrt_toolmanifest))
 
         # Mock pressure vessel
         Path(self.test_user_share, "pressure-vessel", "bin").mkdir(parents=True)
         Path(self.test_user_share, "pressure-vessel", "foo").touch()
         Path(self.test_user_share, "pressure-vessel", "bin", "pv-verify").touch()
+        Path(self.test_user_share, "pressure-vessel", "bin", "steam-runtime-launch-client").write_text(
+            "#!/bin/sh\nexec \"$@\"\n"
+        )
+        Path(self.test_user_share, "pressure-vessel", "bin", "steam-runtime-launch-client").chmod(0o700)
 
         # Mock the proton file in the dir
         self.test_proton_dir.joinpath("proton").touch(exist_ok=True)
+        mock_proton_compatibilitytool = {
+            "compatibilitytools": {
+                "compat_tools": {
+                    self.test_proton_dir.name: {
+                        "install_path": ".",
+                        "display_name": self.test_proton_dir.name,
+                        "from_oslist": "windows",
+                        "to_oslist": "linux",
+                    }
+                }
+            }
+        }
+        self.test_proton_dir.joinpath("compatibilitytool.vdf").write_text(
+            vdf.dumps(mock_proton_compatibilitytool)
+        )
+        mock_proton_toolmanifest = {
+            "manifest": {
+                "version":"2",
+                "commandline": "/proton %verb%",
+                "require_tool_appid": "1628350",
+                "use_sessions": "1",
+                "compatmanager_layer_name": "proton",
+            }
+        }
+        self.test_proton_dir.joinpath("toolmanifest.vdf").write_text(
+            vdf.dumps(mock_proton_toolmanifest)
+        )
 
         # Mock the release downloaded in the cache:
         # tmp.5HYdpddgvs/umu-Proton-5HYdpddgvs.tar.gz
@@ -212,31 +253,25 @@ class TestGameLauncher(unittest.TestCase):
         in the compatibility tool's manifest.
         """
         result = None
-        mock_container_runtimes = (
-            ("sniper", "steamrt3", "1628350"),
-            ("soldier", "steamrt2", "1391110"),
-        )
         # A text file implementing the compatibility tool interface is expected
         # See https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/blob/v0.20251103.0/docs/steam-compat-tool-interface.md?ref_type=tags
-        mock_manifest = (
-            '"manifest"\n'
-            "{\n"
-            '  "version" "2"\n'
-            '  "commandline" "/proton %verb%"\n'
-            '  "require_tool_appid" "769"\n'
-            '  "use_sessions" "1"\n'
-            '  "compatmanager_layer_name" "proton"\n'
-            "}"
-        )
+        mock_manifest = {
+            "manifest": {
+                "version": "2",
+                "commnadline": "/proton %verb%",
+                "require_tool_appid": "769",
+                "use_sessions": "1",
+                "compatmanager_layer_name": "proton",
+            }
+        }
 
         with TemporaryDirectory() as mock_proton:
             Path(mock_proton, "toolmanifest.vdf").write_text(
-                mock_manifest, encoding="utf-8"
+                vdf.dumps(mock_manifest), encoding="utf-8"
             )
-            result = umu_run.get_umu_version_from_manifest(
-                Path(mock_proton, "toolmanifest.vdf"), mock_container_runtimes
-            )
-            self.assertIsNone(result, f"Expected None, received '{result}'")
+            with self.assertRaises(KeyError):
+                result = umu_runtime.CompatLayer(Path(mock_proton), Path()).required_runtime
+                self.assertIsNone(result, f"Expected None, received '{result}'")
 
     def test_get_umu_version_from_manifest_noappid(self):
         """Test get_umu_version_from_manifest.
@@ -246,6 +281,7 @@ class TestGameLauncher(unittest.TestCase):
         exist.
         """
         mock_container_runtimes = (
+            ("host", "", ""),
             ("sniper", "steamrt3", "1628350"),
             ("soldier", "steamrt2", "1391110"),
         )
@@ -263,10 +299,8 @@ class TestGameLauncher(unittest.TestCase):
             Path(mock_proton, "toolmanifest.vdf").write_text(
                 mock_manifest, encoding="utf-8"
             )
-            result = umu_run.get_umu_version_from_manifest(
-                Path(mock_proton, "toolmanifest.vdf"), mock_container_runtimes
-            )
-            self.assertIsNone(result, f"Expected None, received '{result}'")
+            result = umu_runtime.CompatLayer(Path(mock_proton), Path()).required_runtime
+            self.assertEqual(result.as_tuple(), mock_container_runtimes[0], f"Expected None, received '{result}'")
 
     def test_get_umu_version_from_manifest(self):
         """Test get_umu_version_from_manifest.
@@ -293,11 +327,9 @@ class TestGameLauncher(unittest.TestCase):
             Path(mock_proton, "toolmanifest.vdf").write_text(
                 mock_manifest, encoding="utf-8"
             )
-            result = umu_run.get_umu_version_from_manifest(
-                Path(mock_proton, "toolmanifest.vdf"), mock_container_runtimes
-            )
+            result = umu_runtime.CompatLayer(Path(mock_proton), Path()).required_runtime
             self.assertEqual(
-                result,
+                result.as_tuple(),
                 mock_container_runtimes[0],
                 f"Expected '{mock_container_runtimes[0]}, received {result}'",
             )
@@ -308,10 +340,6 @@ class TestGameLauncher(unittest.TestCase):
         Expects None when a known, required runtime is not found in the
         compatibility tool's manifest.
         """
-        mock_container_runtimes = (
-            ("sniper", "steamrt3", "1628350"),
-            ("soldier", "steamrt2", "1391110"),
-        )
         mock_manifest = (
             '"manifest"\n'
             "{\n"
@@ -336,8 +364,9 @@ class TestGameLauncher(unittest.TestCase):
                 f"Expected None, received '{os.environ.get('UMU_NO_PROTON')}",
             )
             os.environ["PROTONPATH"] = mock_proton
-            result = umu_run.resolve_umu_version(mock_container_runtimes)
-            self.assertIsNone(result, f"Expected None, received '{result}'")
+            with self.assertRaises(KeyError):
+                result = umu_run.resolve_runtime()
+                self.assertIsNone(result, f"Expected None, received '{result}'")
 
     def test_resolve_umu_version_noproton(self):
         """Test resolve_umu_version when UMU_NO_PROTON is set.
@@ -361,14 +390,15 @@ class TestGameLauncher(unittest.TestCase):
             f"Expected None, received '{os.environ.get('PROTONPATH')}",
         )
         os.environ["UMU_NO_PROTON"] = "1"
-        result = umu_run.resolve_umu_version(mock_container_runtimes)
+        result = umu_run.resolve_runtime()
         self.assertEqual(
             result,
             mock_expected,
             f"Expected '{mock_expected}', received '{result}'",
         )
-        self.assertTrue(
-            result is mock_container_runtimes[0],
+        self.assertEqual(
+            result,
+            mock_container_runtimes[0],
             f"Expected the original instance '{result}'",
         )
 
@@ -396,14 +426,15 @@ class TestGameLauncher(unittest.TestCase):
             f"Expected None, received '{os.environ.get('UMU_NO_PROTON')}",
         )
         os.environ["PROTONPATH"] = "GE-Proton"
-        result = umu_run.resolve_umu_version(mock_container_runtimes)
+        result = umu_run.resolve_runtime()
         self.assertEqual(
             result,
             mock_expected,
             f"Expected '{mock_expected}', received '{result}'",
         )
-        self.assertTrue(
-            result is mock_container_runtimes[0],
+        self.assertEqual(
+            result,
+            mock_container_runtimes[0],
             f"Expected the original instance '{result}'",
         )
 
@@ -433,14 +464,15 @@ class TestGameLauncher(unittest.TestCase):
             "UMU_NO_PROTON" not in os.environ,
             f"Expected None, received '{os.environ.get('UMU_NO_PROTON')}",
         )
-        result = umu_run.resolve_umu_version(mock_container_runtimes)
+        result = umu_run.resolve_runtime()
         self.assertEqual(
             result,
             mock_container_runtimes[0],
             f"Expected '{mock_expected}', received None",
         )
-        self.assertTrue(
-            result is mock_container_runtimes[0],
+        self.assertEqual(
+            result,
+            mock_container_runtimes[0],
             f"Expected the original instance '{result}'",
         )
 
@@ -467,18 +499,20 @@ class TestGameLauncher(unittest.TestCase):
             f"Expected None, received '{os.environ.get('UMU_NO_PROTON')}",
         )
         os.environ["RUNTIMEPATH"] = "steamrt2"
-        result = umu_run.resolve_umu_version(mock_container_runtimes)
+        result = umu_run.resolve_runtime()
         self.assertEqual(
             result,
             mock_expected,
             f"Expected '{mock_expected}', received None",
         )
-        self.assertTrue(
-            result is mock_container_runtimes[1],
+        self.assertEqual(
+            result,
+            mock_container_runtimes[1],
             f"Expected the original instance '{result}'",
         )
-        self.assertTrue(
-            os.environ["RUNTIMEPATH"] in result,
+        self.assertEqual(
+            os.environ["RUNTIMEPATH"],
+            mock_container_runtimes[1][1],
             f"Expected '{os.environ['RUNTIMEPATH']}' in '{result}'",
         )
 
@@ -522,15 +556,15 @@ class TestGameLauncher(unittest.TestCase):
                 f"Expected None, received '{os.environ.get('UMU_NO_PROTON')}",
             )
             os.environ["PROTONPATH"] = mock_proton
-            result = umu_run.resolve_umu_version(mock_container_runtimes)
+            result = umu_runtime.CompatLayer(Path(os.environ["PROTONPATH"]), Path()).required_runtime
             self.assertEqual(
-                result,
+                result.as_tuple(),
                 mock_expected,
                 f"Expected '{mock_expected}', received None",
             )
             # Ensure the called function did not mutate the input
-            self.assertTrue(
-                result is mock_container_runtimes[0],
+            self.assertEqual(
+                result.as_tuple(), mock_container_runtimes[0],
                 f"Expected the original instance '{result}'",
             )
 
@@ -2227,7 +2261,7 @@ class TestGameLauncher(unittest.TestCase):
             # Config
             result_env, result_dl = umu_run.check_env(self.env)
             # Prefix
-            umu_run.setup_pfx(self.env["WINEPREFIX"])
+            umu_run.setup_pfx(Path(self.env["WINEPREFIX"]))
             # Env
             umu_run.set_env(self.env, args)
 
@@ -2292,7 +2326,7 @@ class TestGameLauncher(unittest.TestCase):
             result_env, result_dl = umu_run.check_env(self.env)
             umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
-            umu_run.setup_pfx(self.env["WINEPREFIX"])
+            umu_run.setup_pfx(Path(self.env["WINEPREFIX"]))
             # Env
             umu_run.set_env(self.env, args)
 
@@ -2390,7 +2424,7 @@ class TestGameLauncher(unittest.TestCase):
             result_env, result_dl = umu_run.check_env(self.env)
             umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
-            umu_run.setup_pfx(self.env["WINEPREFIX"])
+            umu_run.setup_pfx(Path(self.env["WINEPREFIX"]))
             # Env
             umu_run.set_env(self.env, args)
 
@@ -2455,6 +2489,10 @@ class TestGameLauncher(unittest.TestCase):
         # Mock the proton file
         Path(self.test_file, "proton").touch()
 
+        # Mock the shim file
+        shim_path = Path(self.test_local_share_parent, "umu-shim")
+        shim_path.touch()
+
         with (
             patch("sys.argv", ["", self.test_exe]),
             ThreadPoolExecutor() as thread_pool,
@@ -2468,10 +2506,18 @@ class TestGameLauncher(unittest.TestCase):
             # Args
             result_args = __main__.parse_args()
             # Config
+            _ = umu_run.resolve_runtime()
+            # resolve_runtime's backwards compatibility is setting os.environ,
+            # copy it back to self.env
+            self.env["PROTONPATH"] = os.environ["PROTONPATH"]
+            with (
+                patch("umu.umu_proton.UMU_COMPAT", Path(self.test_file).resolve()),
+            ):
+                self.env = umu_proton._get_umu_runtime_tool(self.env, self.env["PROTONPATH"])
             result_env, result_dl = umu_run.check_env(self.env)
             umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
-            umu_run.setup_pfx(self.env["WINEPREFIX"])
+            umu_run.setup_pfx(Path(self.env["WINEPREFIX"]))
             # Env
             umu_run.set_env(self.env, result_args)
             # Game drive
@@ -2506,27 +2552,42 @@ class TestGameLauncher(unittest.TestCase):
                 Path(self.test_user_share, "umu"),
                 Path(self.test_local_share, "umu"),
             )
+            copy(
+                Path(self.test_user_share, "toolmanifest.vdf"),
+                Path(self.test_local_share, "toolmanifest.vdf"),
+            )
+            Path(self.test_local_share, "pressure-vessel").mkdir(exist_ok=True)
+            Path(self.test_local_share, "pressure-vessel", "bin").mkdir(exist_ok=True)
+            copy(
+                Path(self.test_user_share, "pressure-vessel", "bin", "steam-runtime-launch-client"),
+                Path(self.test_local_share, "pressure-vessel", "bin", "steam-runtime-launch-client"),
+            )
 
         # Build
-        test_command = umu_run.build_command(self.env, self.test_local_share_parent, self.test_runtime_default[1])
+        mock_runtime = umu_runtime.UmuRuntime("sniper",  "steamrt3", "1628350", self.test_local_share)
+        with patch("umu.umu_runtime.CompatLayer.required_runtime", mock_runtime):
+            test_command = umu_run.build_command(
+                self.env, umu_runtime.CompatLayer(Path(self.env["PROTONPATH"]), shim_path)
+            )
         self.assertIsInstance(
             test_command, tuple, "Expected a tuple from build_command"
         )
         self.assertEqual(
             len(test_command),
-            5,
+            6,
             f"Expected 5 element, received {len(test_command)}",
         )
 
-        entry_point, opt, verb, sep, exe = [*test_command]
+        entry_point, verb, sep, shim, umutool, exe = [*test_command]
         self.assertEqual(
             entry_point,
-            self.test_local_share / "umu",
+            str(self.test_local_share / "umu"),
             "Expected an entry point",
         )
-        self.assertEqual(opt, "--verb", "Expected --verb")
-        self.assertEqual(verb, "waitforexitandrun", "Expected PROTON_VERB")
+        self.assertEqual(verb, f"--verb={self.test_verb}", "Expected PROTON_VERB")
         self.assertEqual(sep, "--", "Expected --")
+        self.assertEqual(shim, str(shim_path), "Expected path to umu")
+        self.assertEqual(umutool, str(Path(self.test_file, "umu-sniper", "entry-point").resolve()))
         self.assertEqual(exe, self.env["EXE"], "Expected the EXE")
 
     def test_build_command_nopv_appid(self):
@@ -2556,16 +2617,20 @@ class TestGameLauncher(unittest.TestCase):
             '''
         )
 
+        # Mock the shim file
+        shim_path = Path(self.test_local_share_parent, "umu-shim")
+        shim_path.touch()
+
         with (
             patch("sys.argv", ["", self.test_exe]),
             ThreadPoolExecutor() as thread_pool,
         ):
             os.environ["WINEPREFIX"] = self.test_file
-            os.environ["PROTONPATH"] = self.test_file
+            os.environ["PROTONPATH"] = str(self.test_proton_dir.resolve())
             os.environ["GAMEID"] = self.test_file
             os.environ["STORE"] = self.test_file
             os.environ["UMU_NO_RUNTIME"] = "1"
-            version = umu_run.resolve_runtime(self.test_runtime_versions)
+            version = umu_run.resolve_runtime()
             os.environ["RUNTIMEPATH"] = version[1]
             # Args
             result_args = __main__.parse_args()
@@ -2574,7 +2639,7 @@ class TestGameLauncher(unittest.TestCase):
             if version[1]:
                 umu_run.download_proton(result_dl, self.env, thread_pool)
             # Prefix
-            umu_run.setup_pfx(self.env["WINEPREFIX"])
+            umu_run.setup_pfx(Path(self.env["WINEPREFIX"]))
             # Env
             umu_run.set_env(self.env, result_args)
             # Game drive
@@ -2607,27 +2672,41 @@ class TestGameLauncher(unittest.TestCase):
                 Path(self.test_user_share, "umu"),
                 Path(self.test_local_share, "umu"),
             )
+            copy(
+                Path(self.test_user_share, "toolmanifest.vdf"),
+                Path(self.test_local_share, "toolmanifest.vdf"),
+            )
+            Path(self.test_local_share, "pressure-vessel").mkdir(exist_ok=True)
+            Path(self.test_local_share, "pressure-vessel", "bin").mkdir(exist_ok=True)
+            copy(
+                Path(self.test_user_share, "pressure-vessel", "bin", "steam-runtime-launch-client"),
+                Path(self.test_local_share, "pressure-vessel", "bin", "steam-runtime-launch-client"),
+            )
 
         os.environ |= self.env
 
         # Build
-        test_command = umu_run.build_command(self.env, self.test_local_share_parent, version[1])
+        mock_runtime = umu_runtime.UmuRuntime("sniper",  "steamrt3", "1628350", self.test_local_share)
+        with patch("umu.umu_runtime.CompatLayer.required_runtime", mock_runtime):
+            test_command = umu_run.build_command(
+                self.env, umu_runtime.CompatLayer(Path(self.env["PROTONPATH"]), shim_path)
+            )
         self.assertIsInstance(
             test_command, tuple, "Expected a tuple from build_command"
         )
         self.assertEqual(
             len(test_command),
-            8,
-            f"Expected 3 elements, received {len(test_command)}",
+            7,
+            f"Expected 7 elements, received {len(test_command)}",
         )
-        _, _, verb, _, _, proton, _, exe = [*test_command]
-        self.assertIsInstance(proton, os.PathLike, "Expected proton to be PathLike")
+        _, verb, _, _, proton, _, exe = [*test_command]
+        self.assertIsInstance(proton, str, "Expected proton to be str")
         self.assertEqual(
             proton,
-            Path(self.env["PROTONPATH"], "proton"),
+            str(Path(self.env["PROTONPATH"], "proton")),
             "Expected PROTONPATH",
         )
-        self.assertEqual(verb, "waitforexitandrun", "Expected PROTON_VERB")
+        self.assertEqual(verb, "--verb=waitforexitandrun", "Expected PROTON_VERB")
         self.assertEqual(exe, self.env["EXE"], "Expected EXE")
 
     def test_build_command_nopv_noappid(self):
@@ -2645,27 +2724,29 @@ class TestGameLauncher(unittest.TestCase):
         Path(self.test_file, "proton").touch()
         # Mock a non-runtime toolmanifest.vdf
         Path(self.test_file, "toolmanifest.vdf").write_text(
-            '''
-            "manifest"
-            {
-              "version" "2"
-              "commandline" "/proton %verb%"
-              "use_sessions" "1"
-              "compatmanager_layer_name" "proton"
-            }
-            '''
+            vdf.dumps({
+                "manifest": {
+                    "version": "2",
+                    "commandline": "/proton %verb%",
+                    "use_sessions": "1",
+                    "compatmanager_layer_name": "proton",
+                }})
         )
+
+        # Mock the shim file
+        shim_path = Path(self.test_local_share_parent, "umu-shim")
+        shim_path.touch()
 
         with (
             patch("sys.argv", ["", self.test_exe]),
             ThreadPoolExecutor() as thread_pool,
         ):
             os.environ["WINEPREFIX"] = self.test_file
-            os.environ["PROTONPATH"] = self.test_file
+            os.environ["PROTONPATH"] = str(Path(self.test_file).resolve())
             os.environ["GAMEID"] = self.test_file
             os.environ["STORE"] = self.test_file
             os.environ["UMU_NO_RUNTIME"] = "1"
-            version = umu_run.resolve_runtime(self.test_runtime_versions)
+            version = umu_run.resolve_runtime()
             os.environ["RUNTIMEPATH"] = version[1]
             # Args
             result_args = __main__.parse_args()
@@ -2674,7 +2755,7 @@ class TestGameLauncher(unittest.TestCase):
             if version[1]:
                 umu_run.download_proton(result_dl, self.env, thread_pool)
             # Prefix
-            umu_run.setup_pfx(self.env["WINEPREFIX"])
+            umu_run.setup_pfx(Path(self.env["WINEPREFIX"]))
             # Env
             umu_run.set_env(self.env, result_args)
             # Game drive
@@ -2711,20 +2792,22 @@ class TestGameLauncher(unittest.TestCase):
         os.environ |= self.env
 
         # Build
-        test_command = umu_run.build_command(self.env, self.test_local_share_parent, version[1])
+        test_command = umu_run.build_command(
+            self.env, umu_runtime.CompatLayer(Path(self.env["PROTONPATH"]), shim_path)
+        )
         self.assertIsInstance(
             test_command, tuple, "Expected a tuple from build_command"
         )
         self.assertEqual(
             len(test_command),
             4,
-            f"Expected 3 elements, received {len(test_command)}",
+            f"Expected 4 elements, received {len(test_command)}",
         )
         _, proton, verb, exe, *_ = [*test_command]
-        self.assertIsInstance(proton, os.PathLike, "Expected proton to be PathLike")
+        self.assertIsInstance(proton, str, "Expected proton to be str")
         self.assertEqual(
             proton,
-            Path(self.env["PROTONPATH"], "proton"),
+            str(Path(self.env["PROTONPATH"], "proton")),
             "Expected PROTONPATH",
         )
         self.assertEqual(verb, "waitforexitandrun", "Expected PROTON_VERB")
@@ -2754,7 +2837,7 @@ class TestGameLauncher(unittest.TestCase):
             result_env, result_dl = umu_run.check_env(self.env)
             umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
-            umu_run.setup_pfx(self.env["WINEPREFIX"])
+            umu_run.setup_pfx(Path(self.env["WINEPREFIX"]))
             # Env
             umu_run.set_env(self.env, result_args)
             # Mock setting UMU_NO_RUNTIME. This will not be set in the function
@@ -2767,7 +2850,7 @@ class TestGameLauncher(unittest.TestCase):
 
         # Since we didn't create the proton file, an exception should be raised
         with self.assertRaises(FileNotFoundError):
-            umu_run.build_command(self.env, self.test_local_share, self.test_runtime_default[1])
+            umu_run.build_command(self.env, umu_runtime.CompatLayer(Path(self.test_local_share), Path()))
 
     def test_build_command(self):
         """Test build command.
@@ -2792,8 +2875,8 @@ class TestGameLauncher(unittest.TestCase):
             patch("sys.argv", ["", self.test_exe]),
             ThreadPoolExecutor() as thread_pool,
         ):
-            os.environ["WINEPREFIX"] = self.test_file
-            os.environ["PROTONPATH"] = self.test_file
+            os.environ["WINEPREFIX"] = str(Path(self.test_file).resolve())
+            os.environ["PROTONPATH"] = str(self.test_proton_dir.resolve())
             os.environ["GAMEID"] = self.test_file
             os.environ["STORE"] = self.test_file
             os.environ["RUNTIMEPATH"] = self.test_runtime_default[1]
@@ -2803,7 +2886,7 @@ class TestGameLauncher(unittest.TestCase):
             result_env, result_dl = umu_run.check_env(self.env)
             umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
-            umu_run.setup_pfx(self.env["WINEPREFIX"])
+            umu_run.setup_pfx(Path(self.env["WINEPREFIX"]))
             # Env
             umu_run.set_env(self.env, result_args)
             # Game drive
@@ -2839,32 +2922,45 @@ class TestGameLauncher(unittest.TestCase):
                 Path(self.test_user_share, "umu"),
                 Path(self.test_local_share, "umu"),
             )
+            copy(
+                Path(self.test_user_share, "toolmanifest.vdf"),
+                Path(self.test_local_share, "toolmanifest.vdf"),
+            )
+            Path(self.test_local_share, "pressure-vessel").mkdir(exist_ok=True)
+            Path(self.test_local_share, "pressure-vessel", "bin").mkdir(exist_ok=True)
+            copy(
+                Path(self.test_user_share, "pressure-vessel", "bin", "steam-runtime-launch-client"),
+                Path(self.test_local_share, "pressure-vessel", "bin", "steam-runtime-launch-client"),
+            )
 
         # Build
-        test_command = umu_run.build_command(self.env, self.test_local_share_parent, self.test_runtime_default[1])
+        mock_runtime = umu_runtime.UmuRuntime("sniper",  "steamrt3", "1628350", self.test_local_share)
+        with patch("umu.umu_runtime.CompatLayer.required_runtime", mock_runtime):
+            test_command = umu_run.build_command(
+                self.env, umu_runtime.CompatLayer(Path(self.env["PROTONPATH"]), shim_path)
+            )
         self.assertIsInstance(
             test_command, tuple, "Expected a tuple from build_command"
         )
         self.assertEqual(
             len(test_command),
-            8,
-            f"Expected 8 elements, received {len(test_command)}",
+            7,
+            f"Expected 7 elements, received {len(test_command)}",
         )
-        entry_point, opt1, verb, opt2, shim, proton, verb2, exe = [*test_command]
+        entry_point, verb1, sep, shim, proton, verb2, exe = test_command
         # The entry point dest could change. Just check if there's a value
         self.assertTrue(entry_point, "Expected an entry point")
         self.assertIsInstance(
-            entry_point, os.PathLike, "Expected entry point to be PathLike"
+            entry_point, str, "Expected entry point to be string"
         )
-        self.assertEqual(opt1, "--verb", "Expected --verb")
-        self.assertEqual(verb, self.test_verb, "Expected a verb")
-        self.assertEqual(opt2, "--", "Expected --")
-        self.assertIsInstance(shim, os.PathLike, "Expected shim to be PathLike")
-        self.assertEqual(shim, shim_path, "Expected the shim file")
-        self.assertIsInstance(proton, os.PathLike, "Expected proton to be PathLike")
+        self.assertEqual(verb1, f"--verb={self.test_verb}", "Expected a verb")
+        self.assertEqual(sep, "--", "Expected --")
+        self.assertIsInstance(shim, str, "Expected shim to be string")
+        self.assertEqual(shim, str(shim_path), "Expected the shim file")
+        self.assertIsInstance(proton, str, "Expected proton to be string")
         self.assertEqual(
             proton,
-            Path(self.env["PROTONPATH"], "proton"),
+            str(Path(self.env["PROTONPATH"], "proton")),
             "Expected the proton file",
         )
         self.assertEqual(verb2, self.test_verb, "Expected a verb")
@@ -2896,7 +2992,7 @@ class TestGameLauncher(unittest.TestCase):
             result_env, result_dl = umu_run.check_env(self.env)
             umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
-            umu_run.setup_pfx(self.env["WINEPREFIX"])
+            umu_run.setup_pfx(Path(self.env["WINEPREFIX"]))
 
             # Env
             # Confirm that non-normalized paths were passed before setting
@@ -2907,10 +3003,10 @@ class TestGameLauncher(unittest.TestCase):
                 Path(self.test_exe).resolve(),
                 "Expected path to exe to be non-normalized",
             )
-            self.assertNotEqual(
+            self.assertEqual(
                 Path(os.environ["WINEPREFIX"]),
                 Path(os.environ["WINEPREFIX"]).resolve(),
-                "Expected path to exe to be non-normalized",
+                "Expected path to prefix to be normalized",
             )
             self.assertNotEqual(
                 Path(os.environ["PROTONPATH"]),
@@ -2978,7 +3074,7 @@ class TestGameLauncher(unittest.TestCase):
             result_env, result_dl = umu_run.check_env(self.env)
             umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
-            umu_run.setup_pfx(self.env["WINEPREFIX"])
+            umu_run.setup_pfx(Path(self.env["WINEPREFIX"]))
             # Env
             result = umu_run.set_env(self.env, result[0:])
             self.assertTrue(result is self.env, "Expected the same reference")
@@ -3024,18 +3120,13 @@ class TestGameLauncher(unittest.TestCase):
             # Should be stripped -- everything after the hyphen
             self.assertEqual(
                 self.env["STEAM_COMPAT_APP_ID"],
-                umu_id[umu_id.find("-") + 1 :],
-                "Expected STEAM_COMPAT_APP_ID to be the stripped UMU_ID",
-            )
-            self.assertEqual(
-                self.env["SteamAppId"],
-                self.env["STEAM_COMPAT_APP_ID"],
-                "Expected SteamAppId to be STEAM_COMPAT_APP_ID",
+                hashlib.md5(self.env["WINEPREFIX"].encode("utf-8")).hexdigest(),  # noqa: S324
+                "Expected STEAM_COMPAT_APP_ID to be the md5 hashed WINEPREFIX",
             )
             self.assertEqual(
                 self.env["SteamGameId"],
                 self.env["SteamAppId"],
-                "Expected SteamGameId to be STEAM_COMPAT_APP_ID",
+                "Expected SteamGameId to be SteamAppId",
             )
 
             # PATHS
@@ -3087,17 +3178,17 @@ class TestGameLauncher(unittest.TestCase):
             result_env, result_dl = umu_run.check_env(self.env)
             umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
-            umu_run.setup_pfx(self.env["WINEPREFIX"])
+            umu_run.setup_pfx(Path(self.env["WINEPREFIX"]))
             # Env
             self.assertNotEqual(
                 Path(self.test_exe),
                 Path(self.test_exe).resolve(),
                 "Expected path to exe to be non-normalized",
             )
-            self.assertNotEqual(
+            self.assertEqual(
                 Path(os.environ["WINEPREFIX"]),
                 Path(os.environ["WINEPREFIX"]).resolve(),
-                "Expected path to exe to be non-normalized",
+                "Expected path to prefix to be normalized",
             )
             self.assertNotEqual(
                 Path(os.environ["PROTONPATH"]),
@@ -3141,18 +3232,13 @@ class TestGameLauncher(unittest.TestCase):
             )
             self.assertEqual(
                 self.env["STEAM_COMPAT_APP_ID"],
-                "0",
+                hashlib.md5(self.env["WINEPREFIX"].encode("utf-8")).hexdigest(),  # noqa: S324
                 "Expected STEAM_COMPAT_APP_ID to be 0",
-            )
-            self.assertEqual(
-                self.env["SteamAppId"],
-                self.env["STEAM_COMPAT_APP_ID"],
-                "Expected SteamAppId to be STEAM_COMPAT_APP_ID",
             )
             self.assertEqual(
                 self.env["SteamGameId"],
                 self.env["SteamAppId"],
-                "Expected SteamGameId to be STEAM_COMPAT_APP_ID",
+                "Expected SteamGameId to be SteamAppId",
             )
 
             # PATHS
@@ -3204,17 +3290,17 @@ class TestGameLauncher(unittest.TestCase):
             result_env, result_dl = umu_run.check_env(self.env)
             umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
-            umu_run.setup_pfx(self.env["WINEPREFIX"])
+            umu_run.setup_pfx(Path(self.env["WINEPREFIX"]))
             # Env
             self.assertNotEqual(
                 Path(self.test_exe),
                 Path(self.test_exe).resolve(),
                 "Expected path to exe to be non-normalized",
             )
-            self.assertNotEqual(
+            self.assertEqual(
                 Path(os.environ["WINEPREFIX"]),
                 Path(os.environ["WINEPREFIX"]).resolve(),
-                "Expected path to exe to be non-normalized",
+                "Expected path prefix to be normalized",
             )
             self.assertNotEqual(
                 Path(os.environ["PROTONPATH"]),
@@ -3263,18 +3349,13 @@ class TestGameLauncher(unittest.TestCase):
             )
             self.assertEqual(
                 self.env["STEAM_COMPAT_APP_ID"],
-                "0",
+                hashlib.md5(self.env["WINEPREFIX"].encode("utf-8")).hexdigest(),  # noqa: S324
                 "Expected STEAM_COMPAT_APP_ID to be 0",
-            )
-            self.assertEqual(
-                self.env["SteamAppId"],
-                self.env["STEAM_COMPAT_APP_ID"],
-                "Expected SteamAppId to be STEAM_COMPAT_APP_ID",
             )
             self.assertEqual(
                 self.env["SteamGameId"],
                 self.env["SteamAppId"],
-                "Expected SteamGameId to be STEAM_COMPAT_APP_ID",
+                "Expected SteamGameId to be SteamAppId",
             )
 
             # PATHS
@@ -3315,6 +3396,8 @@ class TestGameLauncher(unittest.TestCase):
 
         # Mock a Proton directory that contains winetricks
         test_dir = Path("./tmp.aCAs3Q7rvz")
+        if test_dir.exists():
+            rmtree(test_dir)
         test_dir.joinpath("protonfixes").mkdir(parents=True)
         test_dir.joinpath("protonfixes", "winetricks").touch()
 
@@ -3335,17 +3418,17 @@ class TestGameLauncher(unittest.TestCase):
             result_env, result_dl = umu_run.check_env(self.env)
             umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
-            umu_run.setup_pfx(self.env["WINEPREFIX"])
+            umu_run.setup_pfx(Path(self.env["WINEPREFIX"]))
             # Env
             self.assertNotEqual(
                 Path(test_exe),
                 Path(test_exe).resolve(),
                 "Expected path to exe to be non-normalized",
             )
-            self.assertNotEqual(
+            self.assertEqual(
                 Path(os.environ["WINEPREFIX"]),
                 Path(os.environ["WINEPREFIX"]).resolve(),
-                "Expected path to exe to be non-normalized",
+                "Expected path to prefix to be normalized",
             )
             self.assertNotEqual(
                 Path(os.environ["PROTONPATH"]),
@@ -3393,18 +3476,13 @@ class TestGameLauncher(unittest.TestCase):
             )
             self.assertEqual(
                 self.env["STEAM_COMPAT_APP_ID"],
-                "0",
-                "Expected STEAM_COMPAT_APP_ID to be 0",
-            )
-            self.assertEqual(
-                self.env["SteamAppId"],
-                self.env["STEAM_COMPAT_APP_ID"],
-                "Expected SteamAppId to be STEAM_COMPAT_APP_ID",
+                hashlib.md5(self.env["WINEPREFIX"].encode("utf-8")).hexdigest(),  # noqa: S324
+                "Expected STEAM_COMPAT_APP_ID to be the md5 hash WINEPREFIX",
             )
             self.assertEqual(
                 self.env["SteamGameId"],
                 self.env["SteamAppId"],
-                "Expected SteamGameId to be STEAM_COMPAT_APP_ID",
+                "Expected SteamGameId to be SteamAppId",
             )
 
             # PATHS
@@ -3435,7 +3513,7 @@ class TestGameLauncher(unittest.TestCase):
             )
 
         if test_dir.exists():
-            rmtree(test_dir.as_posix())
+            rmtree(test_dir)
 
     def test_setup_pfx_mv(self):
         """Test setup_pfx when moving the WINEPREFIX after creating it.
@@ -3451,7 +3529,7 @@ class TestGameLauncher(unittest.TestCase):
             "~",
             Path(self.test_file).cwd().joinpath(self.test_file).as_posix(),
         )
-        result = umu_run.setup_pfx(unexpanded_path)
+        result = umu_run.setup_pfx(Path(unexpanded_path))
 
         # Replaces the expanded path to unexpanded
         # Example: ~/some/path/to/this/file -> /home/foo/path/to/this/file
@@ -3502,7 +3580,7 @@ class TestGameLauncher(unittest.TestCase):
             "steamuser"
         ).expanduser().symlink_to(Path(self.test_file).absolute())
 
-        result = umu_run.setup_pfx(unexpanded_path)
+        result = umu_run.setup_pfx(Path(unexpanded_path))
 
         self.assertIsNone(
             result,
@@ -3530,7 +3608,7 @@ class TestGameLauncher(unittest.TestCase):
             self.user
         ).expanduser().mkdir(parents=True, exist_ok=True)
 
-        result = umu_run.setup_pfx(unexpanded_path)
+        result = umu_run.setup_pfx(Path(unexpanded_path))
 
         self.assertIsNone(
             result,
@@ -3570,7 +3648,7 @@ class TestGameLauncher(unittest.TestCase):
             parents=True, exist_ok=True
         )
 
-        result = umu_run.setup_pfx(unexpanded_path)
+        result = umu_run.setup_pfx(Path(unexpanded_path))
 
         self.assertIsNone(
             result,
@@ -3617,7 +3695,7 @@ class TestGameLauncher(unittest.TestCase):
             "~",
             Path(self.test_file).cwd().joinpath(self.test_file).as_posix(),
         )
-        result = umu_run.setup_pfx(unexpanded_path)
+        result = umu_run.setup_pfx(Path(unexpanded_path))
 
         # Replaces the expanded path to unexpanded
         # Example: ~/some/path/to/this/file -> /home/foo/path/to/this/file
@@ -3655,7 +3733,7 @@ class TestGameLauncher(unittest.TestCase):
             "~",
             Path(self.test_file).as_posix(),
         )
-        result = umu_run.setup_pfx(unexpanded_path)
+        result = umu_run.setup_pfx(Path(unexpanded_path))
 
         # Replaces the expanded path to unexpanded
         # Example: ~/some/path/to/this/file -> /home/foo/path/to/this/file
@@ -3675,10 +3753,11 @@ class TestGameLauncher(unittest.TestCase):
 
     def test_setup_pfx_noproton(self):
         """Test setup_pfx when configured to not use Proton."""
+        self.skipTest("setup_pfx() is not called for non-proton tools")
         result = None
         os.environ["UMU_NO_PROTON"] = "1"
 
-        result = umu_run.setup_pfx(self.test_file)
+        result = umu_run.setup_pfx(Path(self.test_file))
         self.assertTrue(result is None, f"Expected None, received {result}")
         self.assertFalse(
             Path(self.test_file, "pfx").exists(),
@@ -3704,7 +3783,7 @@ class TestGameLauncher(unittest.TestCase):
             Path(self.test_file).resolve(),
             "Expected path to be non-normalized",
         )
-        result = umu_run.setup_pfx(self.test_file)
+        result = umu_run.setup_pfx(Path(self.test_file))
         self.assertIsNone(
             result,
             "Expected None when creating symbolic link to WINE prefix and "
@@ -3752,6 +3831,7 @@ class TestGameLauncher(unittest.TestCase):
 
         A SystemExit should be raised in this usage: ./umu_run.py
         """
+        self.skipTest("Exits cleanly")
         with self.assertRaises(SystemExit):
             __main__.parse_args()
 
@@ -3934,10 +4014,11 @@ class TestGameLauncher(unittest.TestCase):
             umu_run.download_proton(result_dl, result_env, thread_pool)
 
         # After this, the WINEPREFIX and new dirs should be created
-        self.assertTrue(
-            Path(self.env["WINEPREFIX"]).exists(),
-            "Expected WINEPREFIX to exist after check_env",
-        )
+        # Update; the prefix is created in setup_pfx
+        # self.assertTrue(
+        #     Path(self.env["WINEPREFIX"]).exists(),
+        #     "Expected WINEPREFIX to exist after check_env",
+        # )
         self.assertEqual(
             self.env["WINEPREFIX"],
             os.environ["WINEPREFIX"],
@@ -3972,7 +4053,7 @@ class TestGameLauncher(unittest.TestCase):
         self.assertTrue(result_env is self.env, "Expected the same reference")
         self.assertEqual(
             self.env["WINEPREFIX"],
-            unexpanded_path,
+            Path(unexpanded_path).expanduser().resolve(strict=True).as_posix(),
             "Expected WINEPREFIX to be set",
         )
         self.assertEqual(
@@ -3998,7 +4079,7 @@ class TestGameLauncher(unittest.TestCase):
         self.assertTrue(result_env is self.env, "Expected the same reference")
         self.assertEqual(
             self.env["WINEPREFIX"],
-            self.test_file,
+            Path(self.test_file).expanduser().resolve(strict=True).as_posix(),
             "Expected WINEPREFIX to be set",
         )
         self.assertEqual(

--- a/umu/vdf/__init__.py
+++ b/umu/vdf/__init__.py
@@ -1,0 +1,521 @@
+"""
+Module for deserializing/serializing to and from VDF
+"""
+__version__ = "3.4"
+__author__ = "Rossen Georgiev"
+
+import re
+import sys
+import struct
+from binascii import crc32
+from io import BytesIO
+from io import StringIO as unicodeIO
+
+try:
+    from collections.abc import Mapping
+except:
+    from collections import Mapping
+
+from .vdict import VDFDict
+
+# Py2 & Py3 compatibility
+if sys.version_info[0] >= 3:
+    string_type = str
+    int_type = int
+    BOMS = '\ufffe\ufeff'
+
+    def strip_bom(line):
+        return line.lstrip(BOMS)
+else:
+    from StringIO import StringIO as strIO
+    string_type = basestring
+    int_type = long
+    BOMS = '\xef\xbb\xbf\xff\xfe\xfe\xff'
+    BOMS_UNICODE = '\\ufffe\\ufeff'.decode('unicode-escape')
+
+    def strip_bom(line):
+        return line.lstrip(BOMS if isinstance(line, str) else BOMS_UNICODE)
+
+# string escaping
+_unescape_char_map = {
+    r"\n": "\n",
+    r"\t": "\t",
+    r"\v": "\v",
+    r"\b": "\b",
+    r"\r": "\r",
+    r"\f": "\f",
+    r"\a": "\a",
+    r"\\": "\\",
+    r"\?": "?",
+    r"\"": "\"",
+    r"\'": "\'",
+}
+_escape_char_map = {v: k for k, v in _unescape_char_map.items()}
+
+def _re_escape_match(m):
+    return _escape_char_map[m.group()]
+
+def _re_unescape_match(m):
+    return _unescape_char_map[m.group()]
+
+def _escape(text):
+    return re.sub(r"[\n\t\v\b\r\f\a\\\?\"']", _re_escape_match, text)
+
+def _unescape(text):
+    return re.sub(r"(\\n|\\t|\\v|\\b|\\r|\\f|\\a|\\\\|\\\?|\\\"|\\')", _re_unescape_match, text)
+
+# parsing and dumping for KV1
+def parse(fp, mapper=dict, merge_duplicate_keys=True, escaped=True):
+    """
+    Deserialize ``s`` (a ``str`` or ``unicode`` instance containing a VDF)
+    to a Python object.
+
+    ``mapper`` specifies the Python object used after deserializetion. ``dict` is
+    used by default. Alternatively, ``collections.OrderedDict`` can be used if you
+    wish to preserve key order. Or any object that acts like a ``dict``.
+
+    ``merge_duplicate_keys`` when ``True`` will merge multiple KeyValue lists with the
+    same key into one instead of overwriting. You can se this to ``False`` if you are
+    using ``VDFDict`` and need to preserve the duplicates.
+    """
+    if not issubclass(mapper, Mapping):
+        raise TypeError("Expected mapper to be subclass of dict, got %s" % type(mapper))
+    if not hasattr(fp, 'readline'):
+        raise TypeError("Expected fp to be a file-like object supporting line iteration")
+
+    stack = [mapper()]
+    expect_bracket = False
+
+    re_keyvalue = re.compile(r'^("(?P<qkey>(?:\\.|[^\\"])*)"|(?P<key>#?[a-z0-9\-\_\\\?$%<>]+))'
+                             r'([ \t]*('
+                             r'"(?P<qval>(?:\\.|[^\\"])*)(?P<vq_end>")?'
+                             r'|(?P<val>(?:(?<!/)/(?!/)|[a-z0-9\-\_\\\?\*\.$<> ])+)'
+                             r'|(?P<sblock>{[ \t]*)(?P<eblock>})?'
+                             r'))?',
+                             flags=re.I)
+
+    for lineno, line in enumerate(fp, 1):
+        if lineno == 1:
+            line = strip_bom(line)
+
+        line = line.lstrip()
+
+        # skip empty and comment lines
+        if line == "" or line[0] == '/':
+            continue
+
+        # one level deeper
+        if line[0] == "{":
+            expect_bracket = False
+            continue
+
+        if expect_bracket:
+            raise SyntaxError("vdf.parse: expected openning bracket",
+                              (getattr(fp, 'name', '<%s>' % fp.__class__.__name__), lineno, 1, line))
+
+        # one level back
+        if line[0] == "}":
+            if len(stack) > 1:
+                stack.pop()
+                continue
+
+            raise SyntaxError("vdf.parse: one too many closing parenthasis",
+                              (getattr(fp, 'name', '<%s>' % fp.__class__.__name__), lineno, 0, line))
+
+        # parse keyvalue pairs
+        while True:
+            match = re_keyvalue.match(line)
+
+            if not match:
+                try:
+                    line += next(fp)
+                    continue
+                except StopIteration:
+                    raise SyntaxError("vdf.parse: unexpected EOF (open key quote?)",
+                                      (getattr(fp, 'name', '<%s>' % fp.__class__.__name__), lineno, 0, line))
+
+            key = match.group('key') if match.group('qkey') is None else match.group('qkey')
+            val = match.group('qval')
+            if val is None:
+                val = match.group('val')
+                if val is not None:
+                    val = val.rstrip()
+                    if val == "":
+                        val = None
+
+            if escaped:
+                key = _unescape(key)
+
+            # we have a key with value in parenthesis, so we make a new dict obj (level deeper)
+            if val is None:
+                if merge_duplicate_keys and key in stack[-1]:
+                    _m = stack[-1][key]
+                    # we've descended a level deeper, if value is str, we have to overwrite it to mapper
+                    if not isinstance(_m, mapper):
+                        _m = stack[-1][key] = mapper()
+                else:
+                    _m = mapper()
+                    stack[-1][key] = _m
+
+                if match.group('eblock') is None:
+                    # only expect a bracket if it's not already closed or on the same line
+                    stack.append(_m)
+                    if match.group('sblock') is None:
+                        expect_bracket = True
+
+            # we've matched a simple keyvalue pair, map it to the last dict obj in the stack
+            else:
+                # if the value is line consume one more line and try to match again,
+                # until we get the KeyValue pair
+                if match.group('vq_end') is None and match.group('qval') is not None:
+                    try:
+                        line += next(fp)
+                        continue
+                    except StopIteration:
+                        raise SyntaxError("vdf.parse: unexpected EOF (open quote for value?)",
+                                          (getattr(fp, 'name', '<%s>' % fp.__class__.__name__), lineno, 0, line))
+
+                stack[-1][key] = _unescape(val) if escaped else val
+
+            # exit the loop
+            break
+
+    if len(stack) != 1:
+        raise SyntaxError("vdf.parse: unclosed parenthasis or quotes (EOF)",
+                           (getattr(fp, 'name', '<%s>' % fp.__class__.__name__), lineno, 0, line))
+
+    return stack.pop()
+
+
+def loads(s, **kwargs):
+    """
+    Deserialize ``s`` (a ``str`` or ``unicode`` instance containing a JSON
+    document) to a Python object.
+    """
+    if not isinstance(s, string_type):
+        raise TypeError("Expected s to be a str, got %s" % type(s))
+
+    try:
+        fp = unicodeIO(s)
+    except TypeError:
+        fp = strIO(s)
+
+    return parse(fp, **kwargs)
+
+
+def load(fp, **kwargs):
+    """
+    Deserialize ``fp`` (a ``.readline()``-supporting file-like object containing
+    a JSON document) to a Python object.
+    """
+    return parse(fp, **kwargs)
+
+
+def dumps(obj, pretty=False, escaped=True):
+    """
+    Serialize ``obj`` to a VDF formatted ``str``.
+    """
+    if not isinstance(obj, Mapping):
+        raise TypeError("Expected data to be an instance of``dict``")
+    if not isinstance(pretty, bool):
+        raise TypeError("Expected pretty to be of type bool")
+    if not isinstance(escaped, bool):
+        raise TypeError("Expected escaped to be of type bool")
+
+    return ''.join(_dump_gen(obj, pretty, escaped))
+
+
+def dump(obj, fp, pretty=False, escaped=True):
+    """
+    Serialize ``obj`` as a VDF formatted stream to ``fp`` (a
+    ``.write()``-supporting file-like object).
+    """
+    if not isinstance(obj, Mapping):
+        raise TypeError("Expected data to be an instance of``dict``")
+    if not hasattr(fp, 'write'):
+        raise TypeError("Expected fp to have write() method")
+    if not isinstance(pretty, bool):
+        raise TypeError("Expected pretty to be of type bool")
+    if not isinstance(escaped, bool):
+        raise TypeError("Expected escaped to be of type bool")
+
+    for chunk in _dump_gen(obj, pretty, escaped):
+        fp.write(chunk)
+
+
+def _dump_gen(data, pretty=False, escaped=True, level=0):
+    indent = "\t"
+    line_indent = ""
+
+    if pretty:
+        line_indent = indent * level
+
+    for key, value in data.items():
+        if escaped and isinstance(key, string_type):
+            key = _escape(key)
+
+        if isinstance(value, Mapping):
+            yield '%s"%s"\n%s{\n' % (line_indent, key, line_indent)
+            for chunk in _dump_gen(value, pretty, escaped, level+1):
+                yield chunk
+            yield "%s}\n" % line_indent
+        else:
+            if escaped and isinstance(value, string_type):
+                value = _escape(value)
+
+            yield '%s"%s" "%s"\n' % (line_indent, key, value)
+
+
+# binary VDF
+class BASE_INT(int_type):
+    def __repr__(self):
+        return "%s(%d)" % (self.__class__.__name__, self)
+
+class UINT_64(BASE_INT):
+    pass
+
+class INT_64(BASE_INT):
+    pass
+
+class POINTER(BASE_INT):
+    pass
+
+class COLOR(BASE_INT):
+    pass
+
+BIN_NONE        = b'\x00'
+BIN_STRING      = b'\x01'
+BIN_INT32       = b'\x02'
+BIN_FLOAT32     = b'\x03'
+BIN_POINTER     = b'\x04'
+BIN_WIDESTRING  = b'\x05'
+BIN_COLOR       = b'\x06'
+BIN_UINT64      = b'\x07'
+BIN_END         = b'\x08'
+BIN_INT64       = b'\x0A'
+BIN_END_ALT     = b'\x0B'
+
+def binary_loads(b, mapper=dict, merge_duplicate_keys=True, alt_format=False, raise_on_remaining=True):
+    """
+    Deserialize ``b`` (``bytes`` containing a VDF in "binary form")
+    to a Python object.
+
+    ``mapper`` specifies the Python object used after deserializetion. ``dict` is
+    used by default. Alternatively, ``collections.OrderedDict`` can be used if you
+    wish to preserve key order. Or any object that acts like a ``dict``.
+
+    ``merge_duplicate_keys`` when ``True`` will merge multiple KeyValue lists with the
+    same key into one instead of overwriting. You can se this to ``False`` if you are
+    using ``VDFDict`` and need to preserve the duplicates.
+    """
+    if not isinstance(b, bytes):
+        raise TypeError("Expected s to be bytes, got %s" % type(b))
+
+    return binary_load(BytesIO(b), mapper, merge_duplicate_keys, alt_format, raise_on_remaining)
+
+def binary_load(fp, mapper=dict, merge_duplicate_keys=True, alt_format=False, raise_on_remaining=False):
+    """
+    Deserialize ``fp`` (a ``.read()``-supporting file-like object containing
+    binary VDF) to a Python object.
+
+    ``mapper`` specifies the Python object used after deserializetion. ``dict` is
+    used by default. Alternatively, ``collections.OrderedDict`` can be used if you
+    wish to preserve key order. Or any object that acts like a ``dict``.
+
+    ``merge_duplicate_keys`` when ``True`` will merge multiple KeyValue lists with the
+    same key into one instead of overwriting. You can se this to ``False`` if you are
+    using ``VDFDict`` and need to preserve the duplicates.
+    """
+    if not hasattr(fp, 'read') or not hasattr(fp, 'tell') or not hasattr(fp, 'seek'):
+        raise TypeError("Expected fp to be a file-like object with tell()/seek() and read() returning bytes")
+    if not issubclass(mapper, Mapping):
+        raise TypeError("Expected mapper to be subclass of dict, got %s" % type(mapper))
+
+    # helpers
+    int32 = struct.Struct('<i')
+    uint64 = struct.Struct('<Q')
+    int64 = struct.Struct('<q')
+    float32 = struct.Struct('<f')
+
+    def read_string(fp, wide=False):
+        buf, end = b'', -1
+        offset = fp.tell()
+
+        # locate string end
+        while end == -1:
+            chunk = fp.read(64)
+
+            if chunk == b'':
+                raise SyntaxError("Unterminated cstring (offset: %d)" % offset)
+
+            buf += chunk
+            end = buf.find(b'\x00\x00' if wide else b'\x00')
+
+        if wide:
+            end += end % 2
+
+        # rewind fp
+        fp.seek(end - len(buf) + (2 if wide else 1), 1)
+
+        # decode string
+        result = buf[:end]
+
+        if wide:
+            result = result.decode('utf-16')
+        elif bytes is not str:
+            result = result.decode('utf-8', 'replace')
+        else:
+            try:
+                result.decode('ascii')
+            except:
+                result = result.decode('utf-8', 'replace')
+
+        return result
+
+    stack = [mapper()]
+    CURRENT_BIN_END = BIN_END if not alt_format else BIN_END_ALT
+
+    for t in iter(lambda: fp.read(1), b''):
+        if t == CURRENT_BIN_END:
+            if len(stack) > 1:
+                stack.pop()
+                continue
+            break
+
+        key = read_string(fp)
+
+        if t == BIN_NONE:
+            if merge_duplicate_keys and key in stack[-1]:
+                _m = stack[-1][key]
+            else:
+                _m = mapper()
+                stack[-1][key] = _m
+            stack.append(_m)
+        elif t == BIN_STRING:
+            stack[-1][key] = read_string(fp)
+        elif t == BIN_WIDESTRING:
+            stack[-1][key] = read_string(fp, wide=True)
+        elif t in (BIN_INT32, BIN_POINTER, BIN_COLOR):
+            val = int32.unpack(fp.read(int32.size))[0]
+
+            if t == BIN_POINTER:
+                val = POINTER(val)
+            elif t == BIN_COLOR:
+                val = COLOR(val)
+
+            stack[-1][key] = val
+        elif t == BIN_UINT64:
+            stack[-1][key] = UINT_64(uint64.unpack(fp.read(int64.size))[0])
+        elif t == BIN_INT64:
+            stack[-1][key] = INT_64(int64.unpack(fp.read(int64.size))[0])
+        elif t == BIN_FLOAT32:
+            stack[-1][key] = float32.unpack(fp.read(float32.size))[0]
+        else:
+            raise SyntaxError("Unknown data type at offset %d: %s" % (fp.tell() - 1, repr(t)))
+
+    if len(stack) != 1:
+        raise SyntaxError("Reached EOF, but Binary VDF is incomplete")
+    if raise_on_remaining and fp.read(1) != b'':
+        fp.seek(-1, 1)
+        raise SyntaxError("Binary VDF ended at offset %d, but there is more data remaining" % (fp.tell() - 1))
+
+    return stack.pop()
+
+def binary_dumps(obj, alt_format=False):
+    """
+    Serialize ``obj`` to a binary VDF formatted ``bytes``.
+    """
+    buf = BytesIO()
+    binary_dump(obj, buf, alt_format)
+    return buf.getvalue()
+
+def binary_dump(obj, fp, alt_format=False):
+    """
+    Serialize ``obj`` to a binary VDF formatted ``bytes`` and write it to ``fp`` filelike object
+    """
+    if not isinstance(obj, Mapping):
+        raise TypeError("Expected obj to be type of Mapping")
+    if not hasattr(fp, 'write'):
+        raise TypeError("Expected fp to have write() method")
+
+    for chunk in _binary_dump_gen(obj, alt_format=alt_format):
+        fp.write(chunk)
+
+def _binary_dump_gen(obj, level=0, alt_format=False):
+    if level == 0 and len(obj) == 0:
+        return
+
+    int32 = struct.Struct('<i')
+    uint64 = struct.Struct('<Q')
+    int64 = struct.Struct('<q')
+    float32 = struct.Struct('<f')
+
+    for key, value in obj.items():
+        if isinstance(key, string_type):
+            key = key.encode('utf-8')
+        else:
+            raise TypeError("dict keys must be of type str, got %s" % type(key))
+
+        if isinstance(value, Mapping):
+            yield BIN_NONE + key + BIN_NONE
+            for chunk in _binary_dump_gen(value, level+1, alt_format=alt_format):
+                yield chunk
+        elif isinstance(value, UINT_64):
+            yield BIN_UINT64 + key + BIN_NONE + uint64.pack(value)
+        elif isinstance(value, INT_64):
+            yield BIN_INT64 + key + BIN_NONE + int64.pack(value)
+        elif isinstance(value, string_type):
+            try:
+                value = value.encode('utf-8') + BIN_NONE
+                yield BIN_STRING
+            except:
+                value = value.encode('utf-16') + BIN_NONE*2
+                yield BIN_WIDESTRING
+            yield key + BIN_NONE + value
+        elif isinstance(value, float):
+            yield BIN_FLOAT32 + key + BIN_NONE + float32.pack(value)
+        elif isinstance(value, (COLOR, POINTER, int, int_type)):
+            if isinstance(value, COLOR):
+                yield BIN_COLOR
+            elif isinstance(value, POINTER):
+                yield BIN_POINTER
+            else:
+                yield BIN_INT32
+            yield key + BIN_NONE
+            yield int32.pack(value)
+        else:
+            raise TypeError("Unsupported type: %s" % type(value))
+
+    yield BIN_END if not alt_format else BIN_END_ALT
+
+
+def vbkv_loads(s, mapper=dict, merge_duplicate_keys=True):
+    """
+    Deserialize ``s`` (``bytes`` containing a VBKV to a Python object.
+
+    ``mapper`` specifies the Python object used after deserializetion. ``dict` is
+    used by default. Alternatively, ``collections.OrderedDict`` can be used if you
+    wish to preserve key order. Or any object that acts like a ``dict``.
+
+    ``merge_duplicate_keys`` when ``True`` will merge multiple KeyValue lists with the
+    same key into one instead of overwriting. You can se this to ``False`` if you are
+    using ``VDFDict`` and need to preserve the duplicates.
+    """
+    if s[:4] != b'VBKV':
+        raise ValueError("Invalid header")
+
+    checksum, = struct.unpack('<i', s[4:8])
+
+    if checksum != crc32(s[8:]):
+        raise ValueError("Invalid checksum")
+
+    return binary_loads(s[8:], mapper, merge_duplicate_keys, alt_format=True)
+
+def vbkv_dumps(obj):
+    """
+    Serialize ``obj`` to a VBKV formatted ``bytes``.
+    """
+    data =  b''.join(_binary_dump_gen(obj, alt_format=True))
+    checksum = crc32(data)
+
+    return b'VBKV' + struct.pack('<i', checksum) + data

--- a/umu/vdf/vdict.py
+++ b/umu/vdf/vdict.py
@@ -1,0 +1,221 @@
+import sys
+from collections import Counter
+
+if sys.version_info[0] >= 3:
+    _iter_values = 'values'
+    _range = range
+    _string_type = str
+    import collections.abc as _c
+    class _kView(_c.KeysView):
+        def __iter__(self):
+            return self._mapping.iterkeys()
+    class _vView(_c.ValuesView):
+        def __iter__(self):
+            return self._mapping.itervalues()
+    class _iView(_c.ItemsView):
+        def __iter__(self):
+            return self._mapping.iteritems()
+else:
+    _iter_values = 'itervalues'
+    _range = xrange
+    _string_type = basestring
+    _kView = lambda x: list(x.iterkeys())
+    _vView = lambda x: list(x.itervalues())
+    _iView = lambda x: list(x.iteritems())
+
+
+class VDFDict(dict):
+    def __init__(self, data=None):
+        """
+        This is a dictionary that supports duplicate keys and preserves insert order
+
+        ``data`` can be a ``dict``, or a sequence of key-value tuples. (e.g. ``[('key', 'value'),..]``)
+        The only supported type for key is str.
+
+        Get/set duplicates is done by tuples ``(index, key)``, where index is the duplicate index
+        for the specified key. (e.g. ``(0, 'key')``, ``(1, 'key')``...)
+
+        When the ``key`` is ``str``, instead of tuple, set will create a duplicate and get will look up ``(0, key)``
+        """
+        self.__omap = []
+        self.__kcount = Counter()
+
+        if data is not None:
+            if not isinstance(data, (list, dict)):
+                raise ValueError("Expected data to be list of pairs or dict, got %s" % type(data))
+            self.update(data)
+
+    def __repr__(self):
+        out = "%s(" % self.__class__.__name__
+        out += "%s)" % repr(list(self.iteritems()))
+        return out
+
+    def __len__(self):
+        return len(self.__omap)
+
+    def _verify_key_tuple(self, key):
+        if len(key) != 2:
+            raise ValueError("Expected key tuple length to be 2, got %d" % len(key))
+        if not isinstance(key[0], int):
+            raise TypeError("Key index should be an int")
+        if not isinstance(key[1], _string_type):
+            raise TypeError("Key value should be a str")
+
+    def _normalize_key(self, key):
+        if isinstance(key, _string_type):
+            key = (0, key)
+        elif isinstance(key, tuple):
+            self._verify_key_tuple(key)
+        else:
+            raise TypeError("Expected key to be a str or tuple, got %s" % type(key))
+        return key
+
+    def __setitem__(self, key, value):
+        if isinstance(key, _string_type):
+            key = (self.__kcount[key], key)
+            self.__omap.append(key)
+        elif isinstance(key, tuple):
+            self._verify_key_tuple(key)
+            if key not in self:
+                raise KeyError("%s doesn't exist" % repr(key))
+        else:
+            raise TypeError("Expected either a str or tuple for key")
+        super(VDFDict, self).__setitem__(key, value)
+        self.__kcount[key[1]] += 1
+
+    def __getitem__(self, key):
+        return super(VDFDict, self).__getitem__(self._normalize_key(key))
+
+    def __delitem__(self, key):
+        key = self._normalize_key(key)
+        result = super(VDFDict, self).__delitem__(key)
+
+        start_idx = self.__omap.index(key)
+        del self.__omap[start_idx]
+
+        dup_idx, skey = key
+        self.__kcount[skey] -= 1
+        tail_count = self.__kcount[skey] - dup_idx
+
+        if tail_count > 0:
+            for idx in _range(start_idx, len(self.__omap)):
+                if self.__omap[idx][1] == skey:
+                    oldkey = self.__omap[idx]
+                    newkey = (dup_idx, skey)
+                    super(VDFDict, self).__setitem__(newkey, self[oldkey])
+                    super(VDFDict, self).__delitem__(oldkey)
+                    self.__omap[idx] = newkey
+
+                    dup_idx += 1
+                    tail_count -= 1
+                    if tail_count == 0:
+                        break
+
+        if self.__kcount[skey] == 0:
+            del self.__kcount[skey]
+
+        return result
+
+    def __iter__(self):
+        return iter(self.iterkeys())
+
+    def __contains__(self, key):
+        return super(VDFDict, self).__contains__(self._normalize_key(key))
+
+    def __eq__(self, other):
+        if isinstance(other, VDFDict):
+            return list(self.items()) == list(other.items())
+        else:
+            return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def clear(self):
+        super(VDFDict, self).clear()
+        self.__kcount.clear()
+        self.__omap = list()
+
+    def get(self, key, *args):
+        return super(VDFDict, self).get(self._normalize_key(key), *args)
+
+    def setdefault(self, key, default=None):
+        if key not in self:
+            self.__setitem__(key, default)
+        return self.__getitem__(key)
+
+    def pop(self, key):
+        key = self._normalize_key(key)
+        value = self.__getitem__(key)
+        self.__delitem__(key)
+        return value
+
+    def popitem(self):
+        if not self.__omap:
+            raise KeyError("VDFDict is empty")
+        key = self.__omap[-1]
+        return key[1], self.pop(key)
+
+    def update(self, data=None, **kwargs):
+        if isinstance(data, dict):
+            data = data.items()
+        elif not isinstance(data, list):
+            raise TypeError("Expected data to be a list or dict, got %s" % type(data))
+
+        for key, value in data:
+            self.__setitem__(key, value)
+
+    def iterkeys(self):
+        return (key[1] for key in self.__omap)
+
+    def keys(self):
+        return _kView(self)
+
+    def itervalues(self):
+        return (self[key] for key in self.__omap)
+
+    def values(self):
+        return _vView(self)
+
+    def iteritems(self):
+        return ((key[1], self[key]) for key in self.__omap)
+
+    def items(self):
+        return _iView(self)
+
+    def get_all_for(self, key):
+        """ Returns all values of the given key """
+        if not isinstance(key, _string_type):
+            raise TypeError("Key needs to be a string.")
+        return [self[(idx, key)] for idx in _range(self.__kcount[key])]
+
+    def remove_all_for(self, key):
+        """ Removes all items with the given key """
+        if not isinstance(key, _string_type):
+            raise TypeError("Key need to be a string.")
+
+        for idx in _range(self.__kcount[key]):
+            super(VDFDict, self).__delitem__((idx, key))
+
+        self.__omap = list(filter(lambda x: x[1] != key, self.__omap))
+
+        del self.__kcount[key]
+
+    def has_duplicates(self):
+        """
+        Returns ``True`` if the dict contains keys with duplicates.
+        Recurses through any all keys with value that is ``VDFDict``.
+        """
+        for n in getattr(self.__kcount, _iter_values)():
+            if n != 1:
+                return True
+
+        def dict_recurse(obj):
+            for v in getattr(obj, _iter_values)():
+                if isinstance(v, VDFDict) and v.has_duplicates():
+                    return True
+                elif isinstance(v, dict):
+                    return dict_recurse(v)
+            return False
+
+        return dict_recurse(self)

--- a/umu/vdf/vdict.py
+++ b/umu/vdf/vdict.py
@@ -2,21 +2,24 @@ import sys
 from collections import Counter
 
 if sys.version_info[0] >= 3:
-    _iter_values = 'values'
+    _iter_values = "values"
     _range = range
     _string_type = str
     import collections.abc as _c
+
     class _kView(_c.KeysView):
         def __iter__(self):
             return self._mapping.iterkeys()
+
     class _vView(_c.ValuesView):
         def __iter__(self):
             return self._mapping.itervalues()
+
     class _iView(_c.ItemsView):
         def __iter__(self):
             return self._mapping.iteritems()
 else:
-    _iter_values = 'itervalues'
+    _iter_values = "itervalues"
     _range = xrange
     _string_type = basestring
     _kView = lambda x: list(x.iterkeys())
@@ -26,8 +29,7 @@ else:
 
 class VDFDict(dict):
     def __init__(self, data=None):
-        """
-        This is a dictionary that supports duplicate keys and preserves insert order
+        """This is a dictionary that supports duplicate keys and preserves insert order
 
         ``data`` can be a ``dict``, or a sequence of key-value tuples. (e.g. ``[('key', 'value'),..]``)
         The only supported type for key is str.
@@ -42,7 +44,9 @@ class VDFDict(dict):
 
         if data is not None:
             if not isinstance(data, (list, dict)):
-                raise ValueError("Expected data to be list of pairs or dict, got %s" % type(data))
+                raise ValueError(
+                    "Expected data to be list of pairs or dict, got %s" % type(data)
+                )
             self.update(data)
 
     def __repr__(self):
@@ -125,8 +129,7 @@ class VDFDict(dict):
     def __eq__(self, other):
         if isinstance(other, VDFDict):
             return list(self.items()) == list(other.items())
-        else:
-            return False
+        return False
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -184,13 +187,13 @@ class VDFDict(dict):
         return _iView(self)
 
     def get_all_for(self, key):
-        """ Returns all values of the given key """
+        """Returns all values of the given key"""
         if not isinstance(key, _string_type):
             raise TypeError("Key needs to be a string.")
         return [self[(idx, key)] for idx in _range(self.__kcount[key])]
 
     def remove_all_for(self, key):
-        """ Removes all items with the given key """
+        """Removes all items with the given key"""
         if not isinstance(key, _string_type):
             raise TypeError("Key need to be a string.")
 
@@ -202,8 +205,7 @@ class VDFDict(dict):
         del self.__kcount[key]
 
     def has_duplicates(self):
-        """
-        Returns ``True`` if the dict contains keys with duplicates.
+        """Returns ``True`` if the dict contains keys with duplicates.
         Recurses through any all keys with value that is ``VDFDict``.
         """
         for n in getattr(self.__kcount, _iter_values)():
@@ -214,7 +216,7 @@ class VDFDict(dict):
             for v in getattr(obj, _iter_values)():
                 if isinstance(v, VDFDict) and v.has_duplicates():
                     return True
-                elif isinstance(v, dict):
+                if isinstance(v, dict):
                     return dict_recurse(v)
             return False
 


### PR DESCRIPTION
* Fixed third-party (non-token) tools failing if their required runtime was not already set-up.
* Replaced `subprojects/vdf` submodule by making it into a local python package
* Removed `UMU_NO_RUNTIME` from the docs
