### PR TITLE
Allow the user/developer to define the location of the umu and Steam folders

### DIFF
--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -78,8 +78,6 @@ if os.environ.get("container") == "flatpak":  # noqa: SIM112
         if os.environ.get("HOST_XDG_DATA_HOME")
         else Path.home().joinpath(".local", "share")
     )
-elif os.environ.get("SNAP"):
-    XDG_DATA_HOME: Path = Path(os.environ["SNAP_REAL_HOME"]).joinpath("AppsFiles", "UMU-launcher")
 else:
     XDG_DATA_HOME: Path = (
         Path(os.environ["XDG_DATA_HOME"])
@@ -96,6 +94,13 @@ UMU_CACHE: Path = XDG_CACHE_HOME.joinpath("umu")
 UMU_COMPAT: Path = XDG_DATA_HOME.joinpath("umu", "compatibilitytools")
 
 STEAM_COMPAT: Path = XDG_DATA_HOME.joinpath("Steam", "compatibilitytools.d")
+
+# Variables to define folders used by UMU
+if "UMU_FOLDER" in os.environ:
+    UMU_LOCAL = Path(os.environ["UMU_FOLDER"]).joinpath("umu")
+    UMU_COMPAT = Path(os.environ["UMU_FOLDER"]).joinpath("umu", "compatibilitytools")
+if "STEAM_COMPAT_FOLDER" in os.environ:
+    STEAM_COMPAT = Path(os.environ["STEAM_COMPAT_FOLDER"]).joinpath("Steam", "compatibilitytools.d")
 
 # Constant defined in prctl.h
 # See prctl(2) for more details

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -79,7 +79,7 @@ if os.environ.get("container") == "flatpak":  # noqa: SIM112
         else Path.home().joinpath(".local", "share")
     )
 elif os.environ.get("SNAP"):
-    XDG_DATA_HOME: Path = Path(os.environ["SNAP_REAL_HOME"])
+    XDG_DATA_HOME: Path = Path(os.environ["SNAP_REAL_HOME"]).joinpath("AppsFiles", "UMU-launcher")
 else:
     XDG_DATA_HOME: Path = (
         Path(os.environ["XDG_DATA_HOME"])

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -95,12 +95,11 @@ UMU_COMPAT: Path = XDG_DATA_HOME.joinpath("umu", "compatibilitytools")
 
 STEAM_COMPAT: Path = XDG_DATA_HOME.joinpath("Steam", "compatibilitytools.d")
 
-# Variables to define folders used by UMU
-if "UMU_FOLDER" in os.environ:
-    UMU_LOCAL = Path(os.environ["UMU_FOLDER"]).joinpath("umu")
-    UMU_COMPAT = Path(os.environ["UMU_FOLDER"]).joinpath("umu", "compatibilitytools")
-if "STEAM_COMPAT_FOLDER" in os.environ:
-    STEAM_COMPAT = Path(os.environ["STEAM_COMPAT_FOLDER"]).joinpath("Steam", "compatibilitytools.d")
+# Variable to define folders used by UMU
+if "UMU_FOLDERS_PATH" in os.environ:
+    UMU_LOCAL = Path(os.environ["UMU_FOLDERS_PATH"]).joinpath("umu")
+    UMU_COMPAT = Path(os.environ["UMU_FOLDERS_PATH"]).joinpath("umu", "compatibilitytools")
+    STEAM_COMPAT = Path(os.environ["UMU_FOLDERS_PATH"]).joinpath("Steam", "compatibilitytools.d")
 
 # Constant defined in prctl.h
 # See prctl(2) for more details

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -85,21 +85,19 @@ else:
         else Path.home().joinpath(".local", "share")
     )
 
-UMU_LOCAL: Path = XDG_DATA_HOME.joinpath("umu")
-
 # Temporary directory for downloaded resources moved from tmpfs
 UMU_CACHE: Path = XDG_CACHE_HOME.joinpath("umu")
 
-# Directory storing Proton and other compatibility tools built against the SLR
-UMU_COMPAT: Path = XDG_DATA_HOME.joinpath("umu", "compatibilitytools")
-
-STEAM_COMPAT: Path = XDG_DATA_HOME.joinpath("Steam", "compatibilitytools.d")
-
-# Variable to define folders used by UMU
+# Define folders used by UMU
+# UMU_COMPAT is a directory storing Proton and other compatibility tools built against the SLR
 if "UMU_FOLDERS_PATH" in os.environ:
     UMU_LOCAL = Path(os.environ["UMU_FOLDERS_PATH"]).joinpath("umu")
     UMU_COMPAT = Path(os.environ["UMU_FOLDERS_PATH"]).joinpath("umu", "compatibilitytools")
     STEAM_COMPAT = Path(os.environ["UMU_FOLDERS_PATH"]).joinpath("Steam", "compatibilitytools.d")
+else:
+    UMU_LOCAL: Path = XDG_DATA_HOME.joinpath("umu")
+    UMU_COMPAT: Path = XDG_DATA_HOME.joinpath("umu", "compatibilitytools")
+    STEAM_COMPAT: Path = XDG_DATA_HOME.joinpath("Steam", "compatibilitytools.d")
 
 # Constant defined in prctl.h
 # See prctl(2) for more details


### PR DESCRIPTION
I noticed that the location used when UMU is being used by a Snap is quite bad, so I'd like to change it.

The problem with the current location is that since the $HOME folder is considered to be the $HOME/.local/share folder, this generates the creation of folders like applications and desktop-directories, polluting the user's $HOME with folders that may not even be useful, and perhaps confusing the user, since a Steam folder is created when umu-run downloads umu-proton.

I chose the AppsFiles folder because it's the same one I use in Zordeer and Meganimus, and I'm trying to make a Snap version of Zordeer.