### PR TITLE
Only consider umu setup if there are files in .local/share/umu/

### DIFF
--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -368,7 +368,7 @@ def extract_tarfile(path: Path, dest: Path) -> Path | None:
 def has_umu_setup(path: Path = UMU_LOCAL) -> bool:
     """Check if umu has been setup in our runtime directory."""
     return path.exists() and any(
-        file for file in path.glob("*") if not file.name.endswith("lock")
+        file for file in path.glob("**/*") if file.is_file() and not file.name.endswith("lock")
     )
 
 


### PR DESCRIPTION
When umu starts downloading the runtime required for the specified tool, it will create a folder for it in UMU_LOCAL. If this download fails, the following code is supposed to catch the error, explain it, and stop the launch:

https://github.com/Open-Wine-Components/umu-launcher/blob/24cdc86a1565764655c9de12404b2c5d12dec6e7/umu/umu_run.py#L888-L894

However, `has_umu_setup` currently only checks whether there is any non-lock file/folder in UMU_LOCAL, meaning the empty runtime directory that was created gets found, and umu is considered "setup".

With this PR, we instead search for non-lock files (not folders) in UMU_LOCAL, which avoids the above issue