### PR TITLE
Do not trust the "Host" header of an HTTP response to be accurate

### DIFF
--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -121,7 +121,7 @@ def _install_umu(
             preload_content=False,
         )
         if resp.status != HTTPStatus.OK:
-            err: str = f"{resp.getheader('Host')} returned the status: {resp.status}"
+            err: str = f"{host} returned the status: {resp.status}"
             raise HTTPError(err)
 
         # Parse data for the archive digest
@@ -139,7 +139,7 @@ def _install_umu(
             HTTPMethod.GET.value, f"{host}{endpoint}/BUILD_ID.txt{token}"
         )
         if resp.status != HTTPStatus.OK:
-            err: str = f"{resp.getheader('Host')} returned the status: {resp.status}"
+            err: str = f"{host} returned the status: {resp.status}"
             raise HTTPError(err)
 
         buildid = resp.data.decode(encoding="utf-8").strip()
@@ -174,7 +174,7 @@ def _install_umu(
             HTTPStatus.PARTIAL_CONTENT,
             HTTPStatus.REQUESTED_RANGE_NOT_SATISFIABLE,
         }:
-            err: str = f"{resp.getheader('Host')} returned the status: {resp.status}"
+            err: str = f"{host} returned the status: {resp.status}"
             raise HTTPError(err)
 
         # Download the runtime
@@ -326,7 +326,7 @@ def _update_umu(
     log.debug("Sending request to '%s' for 'VERSION.txt'...", url)
     resp = http_pool.request(HTTPMethod.GET.value, url)
     if resp.status != HTTPStatus.OK:
-        log.error("%s returned the status: %s", resp.getheader("Host"), resp.status)
+        log.error("%s returned the status: %s", host, resp.status)
         return
 
     # Update our runtime


### PR DESCRIPTION
When encountering an error downloading a file, we often print an error along the lines of "\<host\> returned the status \<status\>". <host> in this case comes from the "Host" response header. When the response is unsuccessful, this header may not contain accurate information. Since we already know the host we're downloading from, we can just print that out instead (most of the time, we already have it in a separate `host` variable, for one case I had to use `urllib.parse`)

For a more concrete example: This issue happened for a user residing in a country with internet censorship. `repo.steampowered.com` is blocked, requests to it fail with a 403 error and no Host header

---

For the case where I added an `urllib.parse` call, I've also went ahead and improved the following scheme validation to *only* accept the `https` scheme:

https://github.com/CommandMC/umu-launcher/blob/2d856d644593de59f0143e6a8638b475d4029a0f/umu/umu_proton.py#L294

Before, this call would've also accepted bogus schemes that start with https (I'm not sure whether that's actually an issue, but it seemed like the correct thing to do now that we have to parse the URL anyway)