### PR TITLE
umu_run: make `pfx` symlink relative to the compat data directory

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -79,12 +79,9 @@ def setup_pfx(path: Path) -> None:
 
     if not path.is_dir():
         path.mkdir(parents=True, exist_ok=True)
+    path = path.resolve(strict=True)
 
     pfx: Path = path.joinpath("pfx")
-    steamuser: Path = path.joinpath("drive_c", "users", "steamuser")
-    # Login name of the user as determined by the password database (pwd)
-    unixuser: str = getpwuid(os.getuid()).pw_name
-    wineuser: Path = path.joinpath("drive_c", "users", unixuser)
 
     path.joinpath("shadercache").mkdir(parents=True, exist_ok=True)
     path.joinpath("gstreamer-1.0").mkdir(parents=True, exist_ok=True)
@@ -93,9 +90,15 @@ def setup_pfx(path: Path) -> None:
         pfx.unlink()
 
     if not pfx.is_dir():
-        pfx.symlink_to(path.resolve(strict=True))
+        # this is a round-trip way to say "."
+        pfx.symlink_to(path.relative_to(path))
 
     path.joinpath("tracked_files").touch()
+
+    steamuser: Path = pfx.joinpath("drive_c", "users", "steamuser")
+    # Login name of the user as determined by the password database (pwd)
+    unixuser: str = getpwuid(os.getuid()).pw_name
+    wineuser: Path = pfx.joinpath("drive_c", "users", unixuser)
 
     # Create a symlink of the current user to the steamuser dir or vice versa
     # Default for a new prefix is: unixuser -> steamuser

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -3778,7 +3778,7 @@ class TestGameLauncher(unittest.TestCase):
 
         # Check if the symlink is in its unexpanded form
         self.assertEqual(
-            Path(self.test_file + "/pfx").readlink().as_posix(),
+            Path(self.test_file + "/pfx").resolve().as_posix(),
             Path(unexpanded_path).expanduser().as_posix(),
         )
 
@@ -3858,7 +3858,7 @@ class TestGameLauncher(unittest.TestCase):
         )
         # Check if the symlink is normalized when passed a relative path
         self.assertEqual(
-            Path(self.test_file + "/pfx").readlink().as_posix(),
+            Path(self.test_file + "/pfx").resolve().as_posix(),
             Path(self.test_file).resolve().as_posix(),
         )
         self.assertTrue(


### PR DESCRIPTION
This makes umu's compatdata folders to movable without the symlink breaking
unexpectedly. The reason to keep the existing folder is that backing up
save and configuration data can be tedious, so being able to move the compat
data folder as a unit can help with that. The other potential issue is proton
making relative symlinks for the prefixes files pointing to the `default_pfx`
shipped with proton, but the proton script should take care of that.

Furthermore, create `drive_c/users/steamuser` and `drive_c/users/<username>`
file hierarchy using the `pfx` folder/symlink. This allows umu to create the
hierarchy under the correct path in case `pfx` already exists and is a folder
(i.e. not the symlink created by umu normally)
