### PR TITLE
When UMU_NO_PROTON is set, run target  inside the 'required runtime' tool of the tool set in PROTONPATH

### DIFF
--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -51,8 +51,8 @@ SessionCaches = tuple[Path, Path]
 class ProtonVersion(Enum):
     """Represent valid version keywords for Proton."""
 
-    GE = "GE-Proton"
-    UMU = "UMU-Proton"
+    GEProton = "GE-Proton"
+    UMUProton = "UMU-Proton"
     GELatest = "GE-Latest"
     UMULatest = "UMU-Latest"
     UMUScout = "umu-scout"
@@ -271,7 +271,7 @@ def _fetch_releases(
     protonpath = os.environ.get("PROTONPATH")
 
     if protonpath in (
-        ProtonVersion.GE.value,
+        ProtonVersion.GEProton.value,
         ProtonVersion.GELatest.value,
     ):
         repo = "/repos/GloriousEggroll/proton-ge-custom/releases/latest"
@@ -453,7 +453,7 @@ def _get_from_compat(
     from a digest mismatch, request failure or unreachable network, the latest
     existing Proton build of that same version will be used
     """
-    version: str = os.environ.get("PROTONPATH", ProtonVersion.UMU.value)
+    version: str = os.environ.get("PROTONPATH", ProtonVersion.UMUProton.value)
 
     for compat in compats:
         try:
@@ -502,7 +502,7 @@ def _get_latest(
     # Name of the Proton directory (e.g., GE-Proton9-7)
     proton: str
     # Name of the Proton version, which is either UMU-Proton or GE-Proton
-    version: str = ProtonVersion.UMU.value
+    version: str = ProtonVersion.UMUProton.value
     lock: str = f"{UMU_LOCAL}/{FileLock.Compat.value}"
     latest_candidates: set[str]
 
@@ -710,7 +710,7 @@ def _get_delta(
         # Apply the patch
         for content in cbor["contents"]:
             src: str = content["source"]
-            if src.startswith((ProtonVersion.GE.value, ProtonVersion.UMU.value)):
+            if src.startswith((ProtonVersion.GEProton.value, ProtonVersion.UMUProton.value)):
                 patchers.append(_apply_delta(proton, content, thread_pool))
                 continue
             subdir: Path | None = next(umu_compat.joinpath(version).rglob(src), None)

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -963,7 +963,8 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
             compat_path: Path = (
                 Path(env["WINEPREFIX"]).expanduser().resolve(strict=False)
             )
-            with unix_flock(f"{UMU_LOCAL}/{FileLock.Prefix.value}"):
+            compat_path.mkdir(parents=True, exist_ok=True)
+            with unix_flock(f"{compat_path}/{FileLock.Prefix.value}"):
                 setup_pfx(compat_path)
 
         # Configure the environment

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -155,9 +155,6 @@ def check_env(env: dict[str, str]) -> tuple[dict[str, str] | dict[str, Any], boo
     env["WINEPREFIX"] = str(pfx)
 
     do_download = False
-    # Skip Proton if running a native Linux executable
-    if os.environ.get("UMU_NO_PROTON") == "1":
-        return env, do_download
 
     # Proton Version
     path: Path = STEAM_COMPAT.joinpath(os.environ.get("PROTONPATH", ""))
@@ -852,8 +849,13 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
         )
         raise ValueError(err)
     # runtime_name, runtime_variant, runtime_appid
-    _, runtime_variant, _ = runtime_version
+    runtime_name, runtime_variant, _ = runtime_version
     os.environ["RUNTIMEPATH"] = runtime_variant
+    # FIXME: When UMU_NO_PROTON is set, but a compatibility tools has also been set,
+    # either manually or automatically, run the required runtime tool of the requested tool.
+    # I.e. if set proton needs steamrt4-arm64, with UMU_NO_PROTON=1 run its required runtime.
+    if os.environ.get("UMU_NO_PROTON") == "1":
+        os.environ["PROTONPATH"] = f"umu-{runtime_name}"
 
     # Test the network environment and fail early if the user is trying
     # to run umu-run offline because an internet connection is required

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -161,8 +161,10 @@ def check_env(env: dict[str, str]) -> tuple[dict[str, str] | dict[str, Any], boo
     if os.environ.get("PROTONPATH") and path.is_dir():
         os.environ["PROTONPATH"] = str(STEAM_COMPAT.joinpath(os.environ["PROTONPATH"]))
 
-    # Proton Codename
-    if os.environ.get("PROTONPATH") in {pver.value for pver in ProtonVersion}:
+    # Proton
+    tool_tokens = {pver.value for pver in ProtonVersion}
+    tool_tokens.remove(ProtonVersion.UMUProton.value)
+    if os.environ.get("PROTONPATH") in tool_tokens:
         do_download = True
 
     if "PROTONPATH" not in os.environ:


### PR DESCRIPTION
- **umu_run: create pfx.lock in the compat_data folder instead of umu's folder**
- **When UMU_NO_PROTON is set, run the 'required runtime' tool of the requested tool.**
