### PR TITLE
Revert "umu_runtime: remove temporary entry point override"

### DIFF
--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -623,6 +623,9 @@ class CompatLayer:
         """Return the tool specific entry point."""
         tool_path = os.path.normpath(self.tool_path)
         cmd = "".join([shlex.quote(tool_path), self.tool_manifest["commandline"]])
+        # Temporary override entry point for backwards compatibility
+        if self.layer_name == "container-runtime" and Path(tool_path).joinpath("umu").is_file():
+            cmd = cmd.replace("_v2-entry-point", "umu")
         cmd = cmd.replace("%verb%", verb)
         return shlex.split(cmd)
 

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -2614,7 +2614,7 @@ class TestGameLauncher(unittest.TestCase):
         entry_point, verb, sep, shim, umutool, exe = [*test_command]
         self.assertEqual(
             entry_point,
-            str(self.test_local_share / "_v2-entry-point"),
+            str(self.test_local_share / "umu"),
             "Expected an entry point",
         )
         self.assertEqual(verb, f"--verb={self.test_verb}", "Expected PROTON_VERB")


### PR DESCRIPTION
This reverts commit d76a7b839b60767f68bada46edfbcc4a2d6ce60c.

Seems like this was premature and there are installations out there
that have `steamrt*/umu` as a file and not a symlink to `_v2-entry-point`.
Furthermore they seem to be missing `_v2-entry-point` completely, so
keep the override for now.

Fixes: https://github.com/Faugus/faugus-launcher/issues/518
