### PR TITLE
build(nix): disable versionCheckHook specifically

### DIFF
--- a/packaging/nix/unwrapped.nix
+++ b/packaging/nix/unwrapped.nix
@@ -67,9 +67,9 @@ in
 
     # The versionCheckHook checks that the derivation's version attribute
     # appears in `umu-run --version`. When building from the flake, the version
-    # is set to the git short rev (e.g. "0993b36"), but the binary always
-    # reports the Python __version__ string (e.g. "1.3.0"). Skip this check.
-    doInstallCheck = false;
-    doCheck = false;
+    # is suffixed with the last modified date (e.g. "1.3.0-unstable-2026-03-11"),
+    # but the binary always reports the Python __version__ string (e.g. "1.3.0").
+    # Skip this check.
+    dontVersionCheck = true;
   }
 )


### PR DESCRIPTION
Small followup to c0efc4ce0cf162f5db107c1f920f5897bba02373 (etc).

Disable `versionCheckHook` specifically, rather than the entire `installCheckPhase`.

Also fix a minor issue in the comment: the version is now commit-date based, rather than SHA based.

Thanks @GloriousEggroll for handling #575 and sorry I wasn't around to respond to pings!
