### PR TITLE
feat: add support for https_proxy environment variable (#415)

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -23,7 +23,7 @@ from tempfile import gettempdir
 from types import FrameType
 from typing import Any
 
-from urllib3 import PoolManager, Retry
+from urllib3 import PoolManager, Retry, ProxyManager
 from urllib3.exceptions import HTTPError
 from urllib3.util import Timeout
 from Xlib import X, Xatom, display
@@ -939,11 +939,20 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
     else:
         timeouts = NET_TIMEOUT
 
+    http_pool: PoolManager
+    if "https_proxy" in os.environ:
+        http_pool = ProxyManager(
+            proxy_url=os.environ["https_proxy"],
+            timeout=Timeout(connect=timeouts, read=timeouts),
+            retries=Retry(total=retries, redirect=True),
+        )
+    else:
+        http_pool = PoolManager(
+            timeout=Timeout(connect=timeouts, read=timeouts),
+            retries=Retry(total=retries, redirect=True),
+        )
     thread_pool = ThreadPoolExecutor()
-    http_pool = PoolManager(
-        timeout=Timeout(connect=timeouts, read=timeouts),
-        retries=Retry(total=retries, redirect=True),
-    )
+
     with thread_pool, http_pool:
         session_pools: tuple[ThreadPoolExecutor, PoolManager] = (thread_pool, http_pool)
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -377,7 +377,9 @@ def build_command(
         )
 
     nsenter: tuple[str, ...] = ()
-    if (launch_client := layer.launch_client) and env.get("UMU_CONTAINER_NSENTER") == "1":
+    if (launch_client := layer.launch_client) and env.get(
+        "UMU_CONTAINER_NSENTER"
+    ) == "1":
         # launch_client is provided by the runtime layer (not arbitrary user input).
         # Resolve via PATH when needed so we execute a concrete binary.
         exe_path: str
@@ -392,9 +394,7 @@ def build_command(
 
         attempts: int = 5
         for trial in range(attempts):
-            with Popen(
-                [exe_path, "--list"], stdout=PIPE, stderr=PIPE
-            ) as proc:  # nosec B603
+            with Popen([exe_path, "--list"], stdout=PIPE, stderr=PIPE) as proc:  # nosec B603
                 out, err = proc.communicate()
             bus_names = out.decode("utf-8").splitlines()
             pfx_bus = "com.steampowered.App" + env["STEAM_COMPAT_APP_ID"]
@@ -761,14 +761,19 @@ def resolve_runtime() -> UmuRuntime:
         os.environ["PROTONPATH"] = ProtonVersion.UMULatest.value
 
     named_runtimes = {
-        RUNTIME_NAMES["steamrt4"]: { ProtonVersion.UMUSteamRT4.value },
-        RUNTIME_NAMES["steamrt4-arm64"]: { ProtonVersion.UMUSteamRT4_arm64.value },
+        RUNTIME_NAMES["steamrt4"]: {ProtonVersion.UMUSteamRT4.value},
+        RUNTIME_NAMES["steamrt4-arm64"]: {ProtonVersion.UMUSteamRT4_arm64.value},
         RUNTIME_NAMES["sniper"]: {
-            ProtonVersion.UMUSniper.value, ProtonVersion.UMULatest.value,
-            ProtonVersion.GEProton.value, ProtonVersion.GELatest.value,
+            ProtonVersion.UMUSniper.value,
+            ProtonVersion.UMULatest.value,
+            ProtonVersion.GEProton.value,
+            ProtonVersion.GELatest.value,
         },
-        RUNTIME_NAMES["sniper-arm64"]: { ProtonVersion.UMUSniper_arm64.value },
-        RUNTIME_NAMES["soldier"]: { ProtonVersion.UMUScout.value, ProtonVersion.UMUSoldier.value },
+        RUNTIME_NAMES["sniper-arm64"]: {ProtonVersion.UMUSniper_arm64.value},
+        RUNTIME_NAMES["soldier"]: {
+            ProtonVersion.UMUScout.value,
+            ProtonVersion.UMUSoldier.value,
+        },
     }
 
     for name in named_runtimes:
@@ -794,9 +799,7 @@ def resolve_runtime() -> UmuRuntime:
         layer = CompatLayer(toolmanifest.parent, Path())
         runtime = layer.required_runtime
     else:
-        err: str = (
-            f"PROTONPATH '{os.environ['PROTONPATH']}' is not valid, toolmanifest.vdf not found"
-        )
+        err: str = f"PROTONPATH '{os.environ['PROTONPATH']}' is not valid, toolmanifest.vdf not found"
         raise FileNotFoundError(err)
 
     return runtime

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -23,7 +23,7 @@ from tempfile import gettempdir
 from types import FrameType
 from typing import Any
 
-from urllib3 import PoolManager, Retry
+from urllib3 import PoolManager, Retry, ProxyManager
 from urllib3.exceptions import HTTPError
 from urllib3.util import Timeout
 from Xlib import X, Xatom, display
@@ -936,11 +936,19 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
     else:
         timeouts = NET_TIMEOUT
 
+    http_pool: PoolManager
+    if "https_proxy" in os.environ:
+        http_pool = ProxyManager(
+            proxy_url=os.environ["https_proxy"],
+            timeout=Timeout(connect=timeouts, read=timeouts),
+            retries=Retry(total=retries, redirect=True),
+        )
+    else:
+        http_pool = PoolManager(
+            timeout=Timeout(connect=timeouts, read=timeouts),
+            retries=Retry(total=retries, redirect=True),
+        )
     thread_pool = ThreadPoolExecutor()
-    http_pool = PoolManager(
-        timeout=Timeout(connect=timeouts, read=timeouts),
-        retries=Retry(total=retries, redirect=True),
-    )
     with thread_pool, http_pool:
         session_pools: tuple[ThreadPoolExecutor, PoolManager] = (thread_pool, http_pool)
 

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -624,7 +624,10 @@ class CompatLayer:
         tool_path = os.path.normpath(self.tool_path)
         cmd = "".join([shlex.quote(tool_path), self.tool_manifest["commandline"]])
         # Temporary override entry point for backwards compatibility
-        if self.layer_name == "container-runtime" and Path(tool_path).joinpath("umu").is_file():
+        if (
+            self.layer_name == "container-runtime"
+            and Path(tool_path).joinpath("umu").is_file()
+        ):
             cmd = cmd.replace("_v2-entry-point", "umu")
         cmd = cmd.replace("%verb%", verb)
         return shlex.split(cmd)

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -119,7 +119,7 @@ def _install_umu(
         # Get the digest for the runtime archive
         resp = http_pool.request(
             HTTPMethod.GET.value,
-            f"{host}{endpoint}/SHA256SUMS{token}",
+            f"https://{host}{endpoint}/SHA256SUMS{token}",
             preload_content=False,
         )
         if resp.status != HTTPStatus.OK:
@@ -138,7 +138,7 @@ def _install_umu(
         # Get BUILD_ID.txt. We'll use the value to identify the file when cached.
         # This will guarantee we'll be picking up the correct file when resuming
         resp = http_pool.request(
-            HTTPMethod.GET.value, f"{host}{endpoint}/BUILD_ID.txt{token}"
+            HTTPMethod.GET.value, f"https://{host}{endpoint}/BUILD_ID.txt{token}"
         )
         if resp.status != HTTPStatus.OK:
             err: str = f"{host} returned the status: {resp.status}"
@@ -165,7 +165,7 @@ def _install_umu(
 
         resp = http_pool.request(
             HTTPMethod.GET.value,
-            f"{host}{endpoint}/{archive}{token}",
+            f"https://{host}{endpoint}/{archive}{token}",
             preload_content=False,
             headers=headers,
         )
@@ -201,7 +201,7 @@ def _install_umu(
                         }
                         resp = http_pool.request(
                             HTTPMethod.GET.value,
-                            f"{host}{endpoint}/{archive}{token}",
+                            f"https://{host}{endpoint}/{archive}{token}",
                             preload_content=False,
                             headers=headers,
                         )
@@ -364,7 +364,7 @@ def _update_umu(
         return
 
     # Fetch the VERSION.txt data
-    url: str = f"{host}{endpoint}/VERSION.txt{token}"
+    url: str = f"https://{host}{endpoint}/VERSION.txt{token}"
     log.debug("Sending request to '%s' for 'VERSION.txt'...", url)
     resp = http_pool.request(HTTPMethod.GET.value, url)
     if resp.status != HTTPStatus.OK:

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -118,7 +118,7 @@ def _install_umu(
         # Get the digest for the runtime archive
         resp = http_pool.request(
             HTTPMethod.GET.value,
-            f"{host}{endpoint}/SHA256SUMS",
+            f"https://{host}{endpoint}/SHA256SUMS",
             preload_content=False,
         )
         if resp.status != HTTPStatus.OK:
@@ -137,7 +137,7 @@ def _install_umu(
         # Get BUILD_ID.txt. We'll use the value to identify the file when cached.
         # This will guarantee we'll be picking up the correct file when resuming
         resp = http_pool.request(
-            HTTPMethod.GET.value, f"{host}{endpoint}/BUILD_ID.txt"
+            HTTPMethod.GET.value, f"https://{host}{endpoint}/BUILD_ID.txt"
         )
         if resp.status != HTTPStatus.OK:
             err: str = f"{host} returned the status: {resp.status}"
@@ -164,7 +164,7 @@ def _install_umu(
 
         resp = http_pool.request(
             HTTPMethod.GET.value,
-            f"{host}{endpoint}/{archive}",
+            f"https://{host}{endpoint}/{archive}",
             preload_content=False,
             headers=headers,
         )
@@ -200,7 +200,7 @@ def _install_umu(
                         }
                         resp = http_pool.request(
                             HTTPMethod.GET.value,
-                            f"{host}{endpoint}/{archive}",
+                            f"https://{host}{endpoint}/{archive}",
                             preload_content=False,
                             headers=headers,
                         )
@@ -275,7 +275,7 @@ def setup_umu(
     codename, variant, _ = runtime_ver
     host: str = "repo.steampowered.com"
     endpoint: str = f"/{variant.removesuffix('-arm64')}/images/latest-public-beta"
-    url: str = f"{host}{endpoint}/VERSION.txt"
+    url: str = f"https://{host}{endpoint}/VERSION.txt"
     log.debug("Sending request to '%s' for 'VERSION.txt'...", url)
     resp = http_pool.request(HTTPMethod.GET.value, url)
     if resp.status != HTTPStatus.OK:


### PR DESCRIPTION
`https_proxy` should be enough. 
Regarding the changes to `umu_runtime.py`, the URL must include a scheme when using `ProxyManager`; otherwise, it will not work.