### PR TITLE
umu_run: gate launcher service behind `UMU_CONTAINER_NSENTER` env var.

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -404,7 +404,7 @@ def build_command(
                 log.info("Re-entering container through bus '%s'", pfx_bus)
                 break
             log.info("Failed to find bus name %s (retry %s)", pfx_bus, trial + 1)
-            time.sleep(2)
+            time.sleep(1)
 
     is_nsenter: bool = bool(nsenter)
     return (
@@ -995,8 +995,9 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
                 setup_pfx(compat_path)
 
         # Configure the environment
-        env["STEAM_COMPAT_LAUNCHER_SERVICE"] = layer.launcher_service
         set_env(env, args)
+        if env.get("UMU_CONTAINER_NSENTER") == "1":
+            env["STEAM_COMPAT_LAUNCHER_SERVICE"] = layer.launcher_service
 
         # Set all environment variables
         # NOTE: `env` after this block should be read only


### PR DESCRIPTION
Launcher service when used modifies the environment to hide GIO modules
https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/blob/main/bin/launcher-service.c#L1701
https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/blob/main/steam-runtime-tools/utils.c#L768

which in turn might cause issues with media playback, for example with NIKKE.

GIO modules are disabled on purpose in certain cases
https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/commit/f6a0a217d4b616ca3ccc2209109ef5e5060812d3

Work-around this by not using the launcher-service machinery unless explicitly requested.
