### PR TITLE
fix: Fix format error in debug message

### DIFF
--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -310,7 +310,7 @@ def _fetch_releases(
 
     if asset_count != asset_max:
         log.warning("Failed to acquire release assets from '%s'", url)
-        log.debug("'%' returned: %s", url, assets)
+        log.debug("'%s' returned: %s", url, assets)
         return ()
 
     return digest_asset, proton_asset


### PR DESCRIPTION
There is a missing 's' in the string message in the string formatting. Correcting '%' to '%s' to avoid raising the format error