### PR TITLE
Fix _fetch_releases() failing on GE-Proton releases with multiple architectures

### DIFF
--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -1,5 +1,6 @@
 import json
 import os
+import platform
 import shutil
 import time
 import urllib.parse
@@ -292,25 +293,38 @@ def _fetch_releases(
     ):
         return ()
 
+    # Releases can ship builds for multiple architectures side by side (e.g.
+    # GE-Proton11-1.tar.gz and GE-Proton11-1-aarch64.tar.gz). Restrict the
+    # search to assets matching the host architecture so the count below
+    # isn't inflated by a build we can't use anyway. umu_runtime.py only
+    # supports these architectures as a host today (anything else raises
+    # at import time), so the default (x86_64) build carries no suffix
+    # and every other supported architecture is called out explicitly here.
+    # Add an entry here if umu-launcher ever supports another host arch.
+    _NON_DEFAULT_ARCH_MARKERS = {"aarch64": "-aarch64"}
+    machine = platform.machine()
+    foreign_markers = tuple(
+        marker for arch, marker in _NON_DEFAULT_ARCH_MARKERS.items() if arch != machine
+    )
     asset_count: int = 0
     asset_max: int = 2
     for asset in assets:
+        if any(marker in asset["name"] for marker in foreign_markers):
+            continue
         if asset["name"].endswith("sum"):
             digest_asset = (asset["name"], asset["browser_download_url"])
             asset_count += 1
-            continue
-        if asset["name"].endswith(("tar.gz", "tar.xz")) and asset["name"].startswith(
+        elif asset["name"].endswith(("tar.gz", "tar.xz")) and asset["name"].startswith(
             ("UMU-Proton", "GE-Proton", "umu-scout")
         ):
             proton_asset = (asset["name"], asset["browser_download_url"])
             asset_count += 1
-            continue
         if asset_count == asset_max:
             break
 
     if asset_count != asset_max:
         log.warning("Failed to acquire release assets from '%s'", url)
-        log.debug("'%' returned: %s", url, assets)
+        log.debug("'%s' returned: %s", url, assets)
         return ()
 
     return digest_asset, proton_asset

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -1931,6 +1931,65 @@ class TestGameLauncher(unittest.TestCase):
             f"Expected tuple with len, received len {result_len}",
         )
 
+    def test_fetch_releases_multi_arch(self):
+        """Test _fetch_releases when a release ships multiple architectures.
+
+        GE-Proton releases can include both x86_64 and aarch64 builds in the
+        same release (e.g. GE-Proton11-1.tar.gz and
+        GE-Proton11-1-aarch64.tar.gz, each with their own .sha512sum). The
+        asset count must not be inflated by assets for a foreign
+        architecture, and the returned assets must match the host arch.
+        """
+        result = None
+        mock_gh_release = {
+            "assets": [
+                {
+                    "name": "GE-Proton11-1-aarch64.sha512sum",
+                    "browser_download_url": "aarch64-sum-url",
+                },
+                {
+                    "name": "GE-Proton11-1-aarch64.tar.gz",
+                    "browser_download_url": "aarch64-tar-url",
+                },
+                {
+                    "name": "GE-Proton11-1.sha512sum",
+                    "browser_download_url": "x86_64-sum-url",
+                },
+                {
+                    "name": "GE-Proton11-1.tar.gz",
+                    "browser_download_url": "x86_64-tar-url",
+                },
+            ]
+        }
+
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.json.return_value = mock_gh_release
+
+        mock_tp = MagicMock()
+        mock_hp = MagicMock()
+        mock_hp.request.return_value = mock_resp
+
+        os.environ["PROTONPATH"] = "GE-Proton"
+
+        with patch.object(umu_proton.platform, "machine", return_value="x86_64"):
+            result = umu_proton._fetch_releases((mock_tp, mock_hp))
+
+        self.assertTrue(result is not None, "Expected a value, received None")
+        self.assertTrue(isinstance(result, tuple), f"Expected tuple, received {result}")
+        self.assertEqual(len(result), 2, f"Expected a 2-tuple, received {result}")
+        digest_asset, proton_asset = result
+        self.assertNotIn(
+            "aarch64",
+            digest_asset[0],
+            "Expected the x86_64 digest asset, received the aarch64 one",
+        )
+        self.assertNotIn(
+            "aarch64",
+            proton_asset[0],
+            "Expected the x86_64 proton asset, received the aarch64 one",
+        )
+
     def test_ge_proton(self):
         """Test check_env when the code name GE-Proton is set for PROTONPATH.
 


### PR DESCRIPTION
Fixes the root cause behind #682 and the crash reported in #686.

`_fetch_releases()` counts matching release assets but only breaks out of the loop from the branch that *doesn't* match either condition — so it never stops once it has what it needs. GE-Proton releases now ship both x86_64 and aarch64 builds side by side (e.g. `GE-Proton11-1.tar.gz` + `GE-Proton11-1-aarch64.tar.gz`, each with a `.sha512sum`), so the loop matches all 4 assets before hitting a non-matching one, `asset_count` (4) never equals `asset_max` (2), and the function reports failure even though the API call succeeded and the right assets were present.

This adds an architecture filter (using `platform.machine()`, consistent with how `umu_runtime.py` already distinguishes host arch) before counting, via an explicit marker table rather than a one-off aarch64 check, and moves the count check so it isn't order-dependent. Also fixes the `log.debug("'%' ...")` format string from #686, which was masking the real error with a secondary logging crash.

Added a regression test reproducing the real 4-asset release shape, for both an x86_64 and an aarch64 host.

Fixes #682
Fixes #686