### PR TITLE
update build workflow for Ubuntu 26.04 to fix #692

### DIFF
--- a/.github/workflows/build-umu-ubuntu-resolute.yml
+++ b/.github/workflows/build-umu-ubuntu-resolute.yml
@@ -1,0 +1,103 @@
+name: UMU Deb Build - Resolute (Ubuntu 26.04 LTS)
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: ubuntu:resolute
+      volumes:
+        - /proc:/proc
+      options: --privileged -it
+
+    steps:
+      - name: Update APT Cache
+        run: apt update -y
+
+      - name: Install build dependencies
+        run: apt install -y dh-make dpkg-dev git
+
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Extract Version and SHA
+        run: |
+          VERSION=$(git describe --tags --abbrev=0 || echo "unknown")
+          echo $VERSION
+
+          # Get current commit SHA
+          COMMIT_SHA=$(git rev-parse HEAD)
+          echo $COMMIT_SHA
+
+          # Store values in environment file
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "COMMIT_SHA=$COMMIT_SHA" >> $GITHUB_ENV
+          sed -i "s|^VERSION := .*$|VERSION := ${VERSION}|g" Makefile.in
+
+          # Always insert latest version into Makefile.in
+          sed -i "s|^VERSION := .*$|VERSION := ${VERSION}|g" Makefile.in
+
+      - name: Initialize submodules
+        run: git submodule update --init --recursive
+
+      - name: Copy debian packaging folder to the repository root
+        run: cp -rvf ./packaging/deb/ubuntu ./debian
+
+      - name: Setup dh_make quilt files
+        run: |
+          sed -re 's|(umu-launcher \()[1-9.]+(-1\).*$)|\1${{ env.VERSION }}\2|' -i ./debian/changelog
+          LOGNAME=root dh_make --createorig -y -l -p umu-launcher_${{ env.VERSION }} || true
+
+      - name: Install apt build dependencies
+        run: apt build-dep -y ./
+
+      - name: Build
+        run: dpkg-buildpackage --no-sign
+
+      - name: Move and rename DEB files to upload artifact path
+        run: |
+          mkdir -p results
+          ARCH=$(dpkg --print-architecture)
+          mv ../python3-umu-launcher_${{ env.VERSION }}-1_${ARCH}.deb \
+             results/python3-umu-launcher_${{ env.VERSION }}-1_${ARCH}_ubuntu-resolute.deb
+
+          # The _all package is architecture-independent; upload from one leg only.
+          if [ "${ARCH}" = "amd64" ]; then
+            mv ../umu-launcher_${{ env.VERSION }}-1_all.deb \
+               results/umu-launcher_${{ env.VERSION }}-1_all_ubuntu-resolute.deb
+          fi
+
+      - name: Upload python3 package
+        uses: actions/upload-artifact@v7
+        with:
+          name: python3-umu-launcher_${{ env.VERSION }}-1_${{ matrix.arch }}_ubuntu-resolute.deb
+          path: results/python3-umu-launcher_${{ env.VERSION }}-1_*_ubuntu-resolute.deb
+
+      - name: Upload _all package
+        if: ${{ matrix.arch == 'amd64' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: umu-launcher_${{ env.VERSION }}-1_all_ubuntu-resolute.deb
+          path: results/umu-launcher_${{ env.VERSION }}-1_all_ubuntu-resolute.deb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,13 @@ jobs:
     with:
       version: ${{ needs.version.outputs.version }}
 
+  ubuntu-resolute-build:
+    name: Ubuntu 26.04 Build
+    uses: ./.github/workflows/build-umu-ubuntu-resolute.yml
+    needs: version
+    with:
+      version: ${{ needs.version.outputs.version }}
+
   zipapp-build:
     name: Zipapp Build
     uses: ./.github/workflows/build-umu-zipapp.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,32 @@ jobs:
       file1: python3-umu-launcher_${{ github.ref_name }}-1_arm64_ubuntu-noble.deb
       name1: python3-umu-launcher_${{ github.ref_name }}-1_arm64_ubuntu-noble.deb
 
+  ubuntu-resolute-build:
+    name: Ubuntu 26.04 Build
+    uses: ./.github/workflows/build-umu-ubuntu-resolute.yml
+    with:
+      version: ${{ github.ref_name }}
+
+  ubuntu-resolute-release-amd64:
+    name: Ubuntu 26.04 Release ${{ github.ref_name }} (amd64)
+    needs: ubuntu-resolute-build
+    uses: ./.github/workflows/build-umu-publish-release.yml
+    with:
+      version: ${{ github.ref_name }}
+      file1: python3-umu-launcher_${{ github.ref_name }}-1_amd64_ubuntu-resolute.deb
+      name1: python3-umu-launcher_${{ github.ref_name }}-1_amd64_ubuntu-resolute.deb
+      file2: umu-launcher_${{ github.ref_name }}-1_all_ubuntu-resolute.deb
+      name2: umu-launcher_${{ github.ref_name }}-1_all_ubuntu-resolute.deb
+
+  ubuntu-resolute-release-arm64:
+    name: Ubuntu 26.04 Release ${{ github.ref_name }} (arm64)
+    needs: ubuntu-resolute-build
+    uses: ./.github/workflows/build-umu-publish-release.yml
+    with:
+      version: ${{ github.ref_name }}
+      file1: python3-umu-launcher_${{ github.ref_name }}-1_arm64_ubuntu-resolute.deb
+      name1: python3-umu-launcher_${{ github.ref_name }}-1_arm64_ubuntu-resolute.deb
+
   zipapp-build:
     name: Zipapp Build
     uses: ./.github/workflows/build-umu-zipapp.yml

--- a/Makefile.in
+++ b/Makefile.in
@@ -93,6 +93,7 @@ $(OBJDIR)/.build-umu-vendored: | $(OBJDIR)
 	fi
 	@if [ "$(USE_SYSTEM_URLLIB)" != "xtrue" ]; then \
 		cd subprojects/urllib3 && \
+		sed -i 's/"setuptools-scm>=8,<9"/"setuptools-scm>=8,<10"/g' pyproject.toml && \
 		sed -i 's/license-files = \["LICENSE.txt"\]//g' pyproject.toml && \
 		$(PYTHON_INTERPRETER) -m build -wn --outdir=$(OBJDIR); \
 	fi

--- a/packaging/deb/0001-deb-fix-build-by-using-rustup.patch
+++ b/packaging/deb/0001-deb-fix-build-by-using-rustup.patch
@@ -4,9 +4,9 @@ Date: Sun, 10 Aug 2025 20:45:09 -0700
 Subject: [PATCH] deb: update rustup patch
 
 ---
- Makefile.in                           | 17 ++++++++++++-----
+ Makefile.in                           | 18 ++++++++++++------
  packaging/deb/debian/bookworm/control |  1 +
- 2 files changed, 13 insertions(+), 5 deletions(-)
+ 2 files changed, 13 insertions(+), 6 deletions(-)
 
 diff --git a/Makefile.in b/Makefile.in
 index 1ad390ff..e4088650 100644
@@ -28,11 +28,12 @@ index 1ad390ff..e4088650 100644
  
  $(OBJDIR)/.build-umu-vendored: | $(OBJDIR)
  	$(info :: Building vendored dependencies )
-@@ -92,9 +94,7 @@ $(OBJDIR)/.build-umu-vendored: | $(OBJDIR)
+@@ -92,10 +94,7 @@ $(OBJDIR)/.build-umu-vendored: | $(OBJDIR)
  		cd subprojects/pyzstd && $(PYTHON_INTERPRETER) -m build -wn -C=--build-option=--dynamic-link-zstd --outdir=$(OBJDIR); \
  	fi
  	@if [ "$(USE_SYSTEM_URLLIB)" != "xtrue" ]; then \
 -		cd subprojects/urllib3 && \
+-		sed -i 's/"setuptools-scm>=8,<9"/"setuptools-scm>=8,<10"/g' pyproject.toml && \
 -		sed -i 's/license-files = \["LICENSE.txt"\]//g' pyproject.toml && \
 -		$(PYTHON_INTERPRETER) -m build -wn --outdir=$(OBJDIR); \
 +		curl -LJO --tlsv1.3 $(URLLIB3_URL) --output-dir $(OBJDIR); \
@@ -81,4 +82,3 @@ index adfd8025..b725d9f5 100644
  Vcs-Browser: https://github.com/Open-Wine-Components/umu-launcher
 -- 
 2.50.1
-


### PR DESCRIPTION
The *_ubuntu-noble.deb package provides a compiled pyzstd extension built for 24.04 Noble’s Python ABI. 

We had not released a 26.04 deb. Users are trying to install 24.04 packages onto Ubuntu 26.04 and so it breaks expecting the python version in 24.04 because pyzstd was built with that version.

To resolve this we need to  add a Resolute build workflow so pyzstd gets built with 26.04's python version.

Fix:
  - Added a Resolute build workflow