### PR TITLE
Don't resolve executable symlinks

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -253,7 +253,8 @@ def set_env(
             # Ensure executable path is absolute, otherwise Proton will fail
             # when creating the subprocess.
             # e.g., Games/umu/umu-0 -> $HOME/Games/umu/umu-0
-            exe: Path = Path(cmd).expanduser().resolve(strict=True)
+            exe: Path = Path(cmd).expanduser().absolute()
+            _ = exe.resolve(strict=True)
             env["EXE"] = str(exe)
             if not env["STEAM_COMPAT_INSTALL_PATH"]:
                 env["STEAM_COMPAT_INSTALL_PATH"] = str(exe.parent)


### PR DESCRIPTION
Right now, the logic for ensuring the executable path is absolute, also resolves any symlinks. That can cause the game to be launched from the wrong directory, potentially giving confusing errors.
My use case involves symlinks from the Nix store, but I'm sure there are many other reasons a Linux user might use symlinks.