### PR TITLE
umu_run: respect STEAM_COMPAT_CLIENT_INSTALL_PATH from client

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -235,6 +235,9 @@ def set_env(
         env["PROTON_VERB"] = "waitforexitandrun"
 
     env["STEAM_COMPAT_INSTALL_PATH"] = os.environ.get("STEAM_COMPAT_INSTALL_PATH", "")
+    env["STEAM_COMPAT_CLIENT_INSTALL_PATH"] = os.environ.get(
+        "STEAM_COMPAT_CLIENT_INSTALL_PATH", ""
+    )
 
     # EXE
     if is_createpfx:


### PR DESCRIPTION
Closes #675.

Read STEAM_COMPAT_CLIENT_INSTALL_PATH from the host environment, the same way STEAM_COMPAT_INSTALL_PATH already is (9689b3a). Unset keeps the current empty default, and umu still never sets it on its own, per the constraint in #675.

Tested on 1.4.4 with GE-Proton11-3: with the variable exported, proton's setup_prefix populates drive_c/Program Files (x86)/Steam from the client's legacycompat and keeps re-syncing those files when the Steam client updates them; without the export, behavior is unchanged.