### PR TITLE
Refuse to use aarch64 runtime on x86_64 machine

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -1,5 +1,6 @@
 import hashlib
 import os
+import platform
 import signal
 import sys
 import threading
@@ -944,6 +945,9 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
             err: str = (
                 f"Failed to match '{os.environ.get('PROTONPATH')}' with a container runtime"
             )
+            raise ValueError(err)
+        if runtime.machine == 'aarch64' and platform.machine() == 'x86_64':
+            err: str = 'Refusing to use aarch64 runtime on x86_64. Did you download the wrong Proton variant?'
             raise ValueError(err)
 
         # runtime_name, runtime_variant, runtime_appid


### PR DESCRIPTION
Users occasionally download the wrong Proton version. At the moment, trying to run an aarch64 Proton on x86_64 with umu will download the required runtime, and attempt to run Proton inside it, which finally fails with a `qemu-aarch64-static: Could not open '/lib/ld-linux-aarch64.so.1': No such file or directory` error (which is hard to understand for the end user).

Instead of having that happen, refuse to use specifically an aarch64 runtime on x86_64.

I did not make this a general `runtime.machine != platform.machine()` check, since I assumed that the other way around (x86_64 runtime on aarch64 host) may be possible with translation layers? If that's not the case though, we may want to harden the check. I just don't have any testing hardware for this case.