### PR TITLE
fix(signal): tolerate already-exited children in signal_handler

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -694,7 +694,13 @@ def signal_handler(sig: int, frame: FrameType | None):  # noqa: ARG001
     """Handle SIGINT/SIGTERM."""
     pstree = get_pstree_from_pid(os.getpid())
     for p in pstree:
-        os.kill(p, sig)
+        try:
+            os.kill(p, sig)
+        except ProcessLookupError:
+            # The child already exited between the pstree snapshot and the
+            # signal. This is a benign race, not an error — continue killing
+            # the remaining descendents instead of aborting the handler.
+            continue
 
 
 def run_command(command: tuple[Path | str, ...]) -> int:


### PR DESCRIPTION
### What changed
The `SIGTERM`/`SIGINT` handler in `umu/umu_run.py` iterates a pstree snapshot
taken a moment earlier and calls `os.kill(p, sig)` on every descendant. If a
child exits between the snapshot and the kill, `os.kill` raises
`ProcessLookupError` and the handler **aborts with an unhandled traceback**.

### Why it matters
Two things go wrong at once:
- The remaining descendants are never signalled (the loop is cut short).
- umu-run itself dies inside the handler (exit status 1) — before
  `proc.wait()` returns — so a parent (e.g. a systemd unit or WiVRn) sees a
  hard failure and the game tree is only reaped incidentally by the cgroup
  sweep, not cleanly.

I hit this live: a VaM (Wine/Proton) process that was already tearing down
when the launcher received `SIGTERM`. The handler crashed on
`ProcessLookupError: [Errno 3] No such process` and the `wivrn-application`
unit failed with status 1 while the game was still "open" for ~30 minutes.

### Fix
Swallow `ProcessLookupError` per-child and `continue`, so the loop keeps
signalling the remaining descendants. This matches the existing use of the
exception in `get_pstree_from_pid()` (same file), which already treats a
vanished PID as a benign race.

### How verified
Reproduced the race directly: spawn two children, kill one, then keep it in a
stale pstree set and deliver `SIGTERM`.
- unpatched: interpreter crashes in the handler with `ProcessLookupError`, exit 1.
- patched: handler completes, exits cleanly, remaining child still receives the signal.

The change adds no imports and no types; `ProcessLookupError` is a builtin
(`OSError` subclass), so it's valid on every Python the CI matrix targets.